### PR TITLE
Add Solutions page with customizable sections

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -574,8 +574,29 @@ video {
   border-width: 0;
 }
 
+.absolute{
+  position: absolute;
+}
+
 .relative{
   position: relative;
+}
+
+.inset-0{
+  inset: 0px;
+}
+
+.inset-x-0{
+  left: 0px;
+  right: 0px;
+}
+
+.bottom-0{
+  bottom: 0px;
+}
+
+.isolate{
+  isolation: isolate;
 }
 
 .z-40{
@@ -603,16 +624,40 @@ video {
   margin-bottom: 1.5rem;
 }
 
+.mt-1{
+  margin-top: 0.25rem;
+}
+
+.mt-12{
+  margin-top: 3rem;
+}
+
+.mt-3{
+  margin-top: 0.75rem;
+}
+
 .mt-4{
   margin-top: 1rem;
+}
+
+.mt-6{
+  margin-top: 1.5rem;
 }
 
 .mt-8{
   margin-top: 2rem;
 }
 
+.mt-auto{
+  margin-top: auto;
+}
+
 .flex{
   display: flex;
+}
+
+.inline-flex{
+  display: inline-flex;
 }
 
 .grid{
@@ -623,8 +668,28 @@ video {
   display: none;
 }
 
+.aspect-\[4\/3\]{
+  aspect-ratio: 4/3;
+}
+
+.h-3\.5{
+  height: 0.875rem;
+}
+
+.h-4{
+  height: 1rem;
+}
+
+.h-40{
+  height: 10rem;
+}
+
 .h-5{
   height: 1.25rem;
+}
+
+.h-6{
+  height: 1.5rem;
 }
 
 .h-full{
@@ -635,8 +700,25 @@ video {
   min-height: 100vh;
 }
 
+.w-3\.5{
+  width: 0.875rem;
+}
+
+.w-4{
+  width: 1rem;
+}
+
 .w-5{
   width: 1.25rem;
+}
+
+.w-6{
+  width: 1.5rem;
+}
+
+.w-fit{
+  width: -moz-fit-content;
+  width: fit-content;
 }
 
 .w-full{
@@ -647,8 +729,16 @@ video {
   max-width: 778px;
 }
 
+.max-w-3xl{
+  max-width: 48rem;
+}
+
 .max-w-4xl{
   max-width: 56rem;
+}
+
+.max-w-6xl{
+  max-width: 72rem;
 }
 
 .max-w-7xl{
@@ -661,6 +751,14 @@ video {
 
 .max-w-none{
   max-width: none;
+}
+
+.flex-1{
+  flex: 1 1 0%;
+}
+
+.flex-none{
+  flex: none;
 }
 
 .transform{
@@ -683,12 +781,40 @@ video {
   flex-direction: column;
 }
 
+.flex-wrap{
+  flex-wrap: wrap;
+}
+
+.items-start{
+  align-items: flex-start;
+}
+
 .items-center{
   align-items: center;
 }
 
+.justify-center{
+  justify-content: center;
+}
+
 .justify-between{
   justify-content: space-between;
+}
+
+.gap-10{
+  gap: 2.5rem;
+}
+
+.gap-12{
+  gap: 3rem;
+}
+
+.gap-2{
+  gap: 0.5rem;
+}
+
+.gap-3{
+  gap: 0.75rem;
 }
 
 .gap-4{
@@ -727,8 +853,28 @@ video {
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
 
+.space-y-6 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-8 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
 .overflow-hidden{
   overflow: hidden;
+}
+
+.rounded-3xl{
+  border-radius: 1.5rem;
+}
+
+.rounded-full{
+  border-radius: 9999px;
 }
 
 .rounded-lg{
@@ -743,6 +889,11 @@ video {
   border-top-width: 1px;
 }
 
+.border-gray-100{
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity, 1));
+}
+
 .border-gray-700{
   --tw-border-opacity: 1;
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
@@ -751,6 +902,14 @@ video {
 .border-gray-800{
   --tw-border-opacity: 1;
   border-color: rgb(31 41 55 / var(--tw-border-opacity, 1));
+}
+
+.border-white\/15{
+  border-color: rgb(255 255 255 / 0.15);
+}
+
+.border-white\/40{
+  border-color: rgb(255 255 255 / 0.4);
 }
 
 .bg-gray-50{
@@ -773,9 +932,61 @@ video {
   background-color: rgb(11 95 255 / var(--tw-bg-opacity, 1));
 }
 
+.bg-primary-light{
+  --tw-bg-opacity: 1;
+  background-color: rgb(230 242 255 / var(--tw-bg-opacity, 1));
+}
+
+.bg-primary-light\/60{
+  background-color: rgb(230 242 255 / 0.6);
+}
+
+.bg-primary\/10{
+  background-color: rgb(11 95 255 / 0.1);
+}
+
+.bg-primary\/15{
+  background-color: rgb(11 95 255 / 0.15);
+}
+
+.bg-slate-900{
+  --tw-bg-opacity: 1;
+  background-color: rgb(15 23 42 / var(--tw-bg-opacity, 1));
+}
+
+.bg-slate-900\/70{
+  background-color: rgb(15 23 42 / 0.7);
+}
+
+.bg-slate-900\/80{
+  background-color: rgb(15 23 42 / 0.8);
+}
+
 .bg-white{
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+
+.bg-white\/10{
+  background-color: rgb(255 255 255 / 0.1);
+}
+
+.bg-white\/90{
+  background-color: rgb(255 255 255 / 0.9);
+}
+
+.bg-white\/95{
+  background-color: rgb(255 255 255 / 0.95);
+}
+
+.bg-gradient-to-t{
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.from-slate-900{
+  --tw-gradient-from: #0f172a var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(15 23 42 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
 .object-contain{
@@ -792,6 +1003,15 @@ video {
   padding: 1.5rem;
 }
 
+.p-8{
+  padding: 2rem;
+}
+
+.px-3{
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
 .px-4{
   padding-left: 1rem;
   padding-right: 1rem;
@@ -802,6 +1022,11 @@ video {
   padding-right: 1.5rem;
 }
 
+.py-1{
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
 .py-12{
   padding-top: 3rem;
   padding-bottom: 3rem;
@@ -810,6 +1035,16 @@ video {
 .py-16{
   padding-top: 4rem;
   padding-bottom: 4rem;
+}
+
+.py-2{
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-20{
+  padding-top: 5rem;
+  padding-bottom: 5rem;
 }
 
 .py-24{
@@ -827,6 +1062,18 @@ video {
   padding-bottom: 1rem;
 }
 
+.pb-6{
+  padding-bottom: 1.5rem;
+}
+
+.pt-2{
+  padding-top: 0.5rem;
+}
+
+.pt-4{
+  padding-top: 1rem;
+}
+
 .pt-6{
   padding-top: 1.5rem;
 }
@@ -839,14 +1086,29 @@ video {
   text-align: center;
 }
 
+.text-2xl{
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .text-3xl{
   font-size: 1.875rem;
   line-height: 2.25rem;
 }
 
+.text-4xl{
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+
 .text-8xl{
   font-size: 6rem;
   line-height: 1;
+}
+
+.text-base{
+  font-size: 1rem;
+  line-height: 1.5rem;
 }
 
 .text-lg{
@@ -870,12 +1132,25 @@ video {
   line-height: 1.75rem;
 }
 
+.text-xs{
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
 .font-bold{
   font-weight: 700;
 }
 
+.font-medium{
+  font-weight: 500;
+}
+
 .font-semibold{
   font-weight: 600;
+}
+
+.uppercase{
+  text-transform: uppercase;
 }
 
 .leading-relaxed{
@@ -890,9 +1165,22 @@ video {
   line-height: 1.25;
 }
 
+.tracking-\[0\.2em\]{
+  letter-spacing: 0.2em;
+}
+
+.tracking-\[0\.3em\]{
+  letter-spacing: 0.3em;
+}
+
 .text-gray-200{
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-300{
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-400{
@@ -900,9 +1188,19 @@ video {
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
 }
 
+.text-gray-500{
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
 .text-gray-600{
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-700{
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-900{
@@ -913,6 +1211,16 @@ video {
 .text-primary{
   --tw-text-opacity: 1;
   color: rgb(11 95 255 / var(--tw-text-opacity, 1));
+}
+
+.text-primary-light{
+  --tw-text-opacity: 1;
+  color: rgb(230 242 255 / var(--tw-text-opacity, 1));
+}
+
+.text-slate-900{
+  --tw-text-opacity: 1;
+  color: rgb(15 23 42 / var(--tw-text-opacity, 1));
 }
 
 .text-white{
@@ -943,14 +1251,77 @@ video {
   opacity: 0.6;
 }
 
+.mix-blend-multiply{
+  mix-blend-mode: multiply;
+}
+
+.shadow-\[0_20px_60px_-30px_rgba\(15\2c 23\2c 42\2c 0\.3\)\]{
+  --tw-shadow: 0 20px 60px -30px rgba(15,23,42,0.3);
+  --tw-shadow-colored: 0 20px 60px -30px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_30px_60px_-35px_rgba\(15\2c 23\2c 42\2c 0\.35\)\]{
+  --tw-shadow: 0 30px 60px -35px rgba(15,23,42,0.35);
+  --tw-shadow-colored: 0 30px 60px -35px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_35px_80px_-40px_rgba\(15\2c 23\2c 42\2c 0\.45\)\]{
+  --tw-shadow: 0 35px 80px -40px rgba(15,23,42,0.45);
+  --tw-shadow-colored: 0 35px 80px -40px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_40px_90px_-40px_rgba\(15\2c 23\2c 42\2c 0\.45\)\]{
+  --tw-shadow: 0 40px 90px -40px rgba(15,23,42,0.45);
+  --tw-shadow-colored: 0 40px 90px -40px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-lg{
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-primary\/30{
+  --tw-shadow-color: rgb(11 95 255 / 0.3);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
 .filter{
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.backdrop-blur{
+  --tw-backdrop-blur: blur(8px);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
+.transition{
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 .transition-colors{
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
+}
+
+.duration-300{
+  transition-duration: 300ms;
+}
+
+.duration-500{
+  transition-duration: 500ms;
+}
+
+.hover\:-translate-y-1:hover{
+  --tw-translate-y: -0.25rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .hover\:bg-primary-dark:hover{
@@ -963,6 +1334,17 @@ video {
   color: rgb(11 95 255 / var(--tw-text-opacity, 1));
 }
 
+.hover\:text-primary-dark:hover{
+  --tw-text-opacity: 1;
+  color: rgb(8 71 191 / var(--tw-text-opacity, 1));
+}
+
+.hover\:shadow-\[0_30px_70px_-30px_rgba\(15\2c 23\2c 42\2c 0\.35\)\]:hover{
+  --tw-shadow: 0 30px 70px -30px rgba(15,23,42,0.35);
+  --tw-shadow-colored: 0 30px 70px -30px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .focus\:border-primary:focus{
   --tw-border-opacity: 1;
   border-color: rgb(11 95 255 / var(--tw-border-opacity, 1));
@@ -971,6 +1353,24 @@ video {
 .focus\:outline-none:focus{
   outline: 2px solid transparent;
   outline-offset: 2px;
+}
+
+.group:hover .group-hover\:scale-105{
+  --tw-scale-x: 1.05;
+  --tw-scale-y: 1.05;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+@media (min-width: 640px){
+
+  .sm\:grid-cols-2{
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sm\:px-6{
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 }
 
 @media (min-width: 768px){
@@ -989,6 +1389,10 @@ video {
 
   .md\:max-w-\[775px\]{
     max-width: 775px;
+  }
+
+  .md\:grid-cols-2{
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .md\:grid-cols-4{
@@ -1021,7 +1425,73 @@ video {
     padding-bottom: 4rem;
   }
 
+  .md\:py-28{
+    padding-top: 7rem;
+    padding-bottom: 7rem;
+  }
+
   .md\:pt-8{
     padding-top: 2rem;
+  }
+
+  .md\:text-4xl{
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
+
+  .md\:text-5xl{
+    font-size: 3rem;
+    line-height: 1;
+  }
+}
+
+@media (min-width: 1024px){
+
+  .lg\:grid-cols-2{
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lg\:grid-cols-\[1\.1fr_1fr\]{
+    grid-template-columns: 1.1fr 1fr;
+  }
+
+  .lg\:flex-row{
+    flex-direction: row;
+  }
+
+  .lg\:flex-row-reverse{
+    flex-direction: row-reverse;
+  }
+
+  .lg\:items-start{
+    align-items: flex-start;
+  }
+
+  .lg\:items-center{
+    align-items: center;
+  }
+
+  .lg\:gap-16{
+    gap: 4rem;
+  }
+
+  .lg\:py-32{
+    padding-top: 8rem;
+    padding-bottom: 8rem;
+  }
+
+  .lg\:text-\[56px\]{
+    font-size: 56px;
+  }
+
+  .lg\:leading-\[1\.05\]{
+    line-height: 1.05;
+  }
+}
+
+@media (min-width: 1280px){
+
+  .xl\:grid-cols-4{
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -574,6 +574,10 @@ video {
   border-width: 0;
 }
 
+.static{
+  position: static;
+}
+
 .absolute{
   position: absolute;
 }

--- a/functions.php
+++ b/functions.php
@@ -5,4 +5,5 @@
 
 require_once get_template_directory() . '/inc/setup.php';
 require_once get_template_directory() . '/inc/assets.php';
+require_once get_template_directory() . '/inc/solutions.php';
 require_once get_template_directory() . '/inc/customizer.php';

--- a/header.php
+++ b/header.php
@@ -8,7 +8,8 @@
 <body <?php body_class('antialiased text-gray-900 bg-white'); ?>>
 <header class="site-header">
   <?php
-  $solutions_page_url = figma_rebuild_get_solutions_page_url();
+  $solutions_page     = get_page_by_path('solutions');
+  $solutions_page_url = $solutions_page ? get_permalink($solutions_page) : '#solutions';
   ?>
 
   <div class="header-container">
@@ -21,7 +22,7 @@
     
     <!-- Navigation - Centered -->
     <nav class="main-navigation" role="navigation" aria-label="<?php esc_attr_e('Primary Menu', 'figma-rebuild'); ?>">
-      <a href="<?php echo esc_url($solutions_page_url); ?>" class="nav-link"><?php esc_html_e('Solutions', 'figma-rebuild'); ?></a>
+      <a href="#solutions" class="nav-link"><?php esc_html_e('Solutions', 'figma-rebuild'); ?></a>
       <a href="#products" class="nav-link"><?php esc_html_e('Products', 'figma-rebuild'); ?></a>
       <a href="#partnership" class="nav-link"><?php esc_html_e('Partnership', 'figma-rebuild'); ?></a>
       <a href="#about" class="nav-link"><?php esc_html_e('About', 'figma-rebuild'); ?></a>
@@ -43,7 +44,7 @@
   <!-- Mobile menu -->
   <div class="mobile-menu" id="mobile-menu">
     <div class="px-6 py-4 space-y-4 max-w-7xl mx-auto">
-      <a href="<?php echo esc_url($solutions_page_url); ?>" class="nav-link">Solutions</a>
+      <a href="#solutions" class="nav-link">Solutions</a>
       <a href="#products" class="nav-link">Products</a>
       <a href="#partnership" class="nav-link">Partnership</a>
       <a href="#about" class="nav-link">About</a>

--- a/header.php
+++ b/header.php
@@ -8,8 +8,7 @@
 <body <?php body_class('antialiased text-gray-900 bg-white'); ?>>
 <header class="site-header">
   <?php
-  $solutions_page     = get_page_by_path('solutions');
-  $solutions_page_url = $solutions_page ? get_permalink($solutions_page) : '#solutions';
+  $solutions_page_url = figma_rebuild_get_solutions_page_url();
   ?>
 
   <div class="header-container">

--- a/header.php
+++ b/header.php
@@ -7,6 +7,11 @@
 </head>
 <body <?php body_class('antialiased text-gray-900 bg-white'); ?>>
 <header class="site-header">
+  <?php
+  $solutions_page     = get_page_by_path('solutions');
+  $solutions_page_url = $solutions_page ? get_permalink($solutions_page) : '#solutions';
+  ?>
+
   <div class="header-container">
     <!-- Logo -->
     <a href="<?php echo esc_url(home_url('/')); ?>" class="logo-container">
@@ -17,7 +22,7 @@
     
     <!-- Navigation - Centered -->
     <nav class="main-navigation" role="navigation" aria-label="<?php esc_attr_e('Primary Menu', 'figma-rebuild'); ?>">
-      <a href="#solutions" class="nav-link"><?php esc_html_e('Solutions', 'figma-rebuild'); ?></a>
+      <a href="<?php echo esc_url($solutions_page_url); ?>" class="nav-link"><?php esc_html_e('Solutions', 'figma-rebuild'); ?></a>
       <a href="#products" class="nav-link"><?php esc_html_e('Products', 'figma-rebuild'); ?></a>
       <a href="#partnership" class="nav-link"><?php esc_html_e('Partnership', 'figma-rebuild'); ?></a>
       <a href="#about" class="nav-link"><?php esc_html_e('About', 'figma-rebuild'); ?></a>
@@ -39,7 +44,7 @@
   <!-- Mobile menu -->
   <div class="mobile-menu" id="mobile-menu">
     <div class="px-6 py-4 space-y-4 max-w-7xl mx-auto">
-      <a href="#solutions" class="nav-link">Solutions</a>
+      <a href="<?php echo esc_url($solutions_page_url); ?>" class="nav-link">Solutions</a>
       <a href="#products" class="nav-link">Products</a>
       <a href="#partnership" class="nav-link">Partnership</a>
       <a href="#about" class="nav-link">About</a>

--- a/header.php
+++ b/header.php
@@ -22,7 +22,7 @@
     
     <!-- Navigation - Centered -->
     <nav class="main-navigation" role="navigation" aria-label="<?php esc_attr_e('Primary Menu', 'figma-rebuild'); ?>">
-      <a href="#solutions" class="nav-link"><?php esc_html_e('Solutions', 'figma-rebuild'); ?></a>
+      <a href="<?php echo esc_url($solutions_page_url); ?>" class="nav-link"><?php esc_html_e('Solutions', 'figma-rebuild'); ?></a>
       <a href="#products" class="nav-link"><?php esc_html_e('Products', 'figma-rebuild'); ?></a>
       <a href="#partnership" class="nav-link"><?php esc_html_e('Partnership', 'figma-rebuild'); ?></a>
       <a href="#about" class="nav-link"><?php esc_html_e('About', 'figma-rebuild'); ?></a>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -10,39 +10,23 @@ if (class_exists('WP_Customize_Control') && !class_exists('Figma_Rebuild_Repeate
    */
   class Figma_Rebuild_Repeater_Control extends WP_Customize_Control {
     public $type = 'figma_repeater';
-
-    /**
-     * @var array[]
-     */
+    /** @var array[] */
     public $fields = [];
-
-    /**
-     * @var string
-     */
+    /** @var string */
     public $add_button_label = '';
-
-    /**
-     * @var string
-     */
+    /** @var string */
     public $item_label = '';
 
-    /**
-     * Render control markup.
-     */
     public function render_content() {
-      if (empty($this->fields)) {
-        return;
-      }
+      if (empty($this->fields)) return;
 
       $value = $this->value();
       $items = json_decode($value, true);
-      if (!is_array($items)) {
-        $items = [];
-      }
+      if (!is_array($items)) $items = [];
 
       $fields_json = wp_json_encode($this->fields);
-      $add_label = $this->add_button_label ?: __('Add Item', 'figma-rebuild');
-      $item_label = $this->item_label ?: __('Item', 'figma-rebuild');
+      $add_label   = $this->add_button_label ?: __('Add Item', 'figma-rebuild');
+      $item_label  = $this->item_label ?: __('Item', 'figma-rebuild');
 
       echo '<div class="figma-repeater" data-fields="' . esc_attr($fields_json) . '">';
 
@@ -66,23 +50,11 @@ if (class_exists('WP_Customize_Control') && !class_exists('Figma_Rebuild_Repeate
       echo '<input type="hidden" class="figma-repeater__store" ' . $this->get_link() . ' value="' . esc_attr(wp_json_encode($items)) . '" />';
 
       echo '<template class="figma-repeater__template">' . $this->get_item_markup([], $item_label) . '</template>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
       echo '</div>';
     }
 
-    /**
-     * Generate markup for a single repeater item.
-     *
-     * @param array  $item       Item values.
-     * @param string $item_label Item label base text.
-     *
-     * @return string
-     */
     protected function get_item_markup($item = [], $item_label = '') {
-      if (!is_array($item)) {
-        $item = [];
-      }
-
+      if (!is_array($item)) $item = [];
       $label = $item_label ?: __('Item', 'figma-rebuild');
 
       ob_start();
@@ -94,13 +66,11 @@ if (class_exists('WP_Customize_Control') && !class_exists('Figma_Rebuild_Repeate
 
       foreach ($this->fields as $field) {
         $field_id = isset($field['id']) ? $field['id'] : '';
-        if (!$field_id) {
-          continue;
-        }
+        if (!$field_id) continue;
 
         $label_text = isset($field['label']) ? $field['label'] : $field_id;
-        $type = isset($field['type']) ? $field['type'] : 'text';
-        $value = isset($item[$field_id]) ? $item[$field_id] : '';
+        $type       = isset($field['type']) ? $field['type'] : 'text';
+        $value      = isset($item[$field_id]) ? $item[$field_id] : '';
 
         echo '<label class="figma-repeater__field">';
         echo '<span class="figma-repeater__field-label">' . esc_html($label_text) . '</span>';
@@ -116,21 +86,12 @@ if (class_exists('WP_Customize_Control') && !class_exists('Figma_Rebuild_Repeate
       }
 
       echo '</div>';
-
       return trim(ob_get_clean());
     }
   }
 }
 
 if (!function_exists('figma_rebuild_sanitize_repeater')) {
-  /**
-   * Sanitize repeater values coming from the Customizer.
-   *
-   * @param mixed $input  Raw input (JSON string).
-   * @param array $fields Field definitions.
-   *
-   * @return string JSON encoded sanitized array.
-   */
   function figma_rebuild_sanitize_repeater($input, $fields) {
     if (is_string($input)) {
       $decoded = json_decode($input, true);
@@ -139,28 +100,19 @@ if (!function_exists('figma_rebuild_sanitize_repeater')) {
     } else {
       $decoded = [];
     }
-
-    if (!is_array($decoded)) {
-      $decoded = [];
-    }
+    if (!is_array($decoded)) $decoded = [];
 
     $sanitized = [];
-
     foreach ($decoded as $item) {
-      if (!is_array($item)) {
-        continue;
-      }
+      if (!is_array($item)) continue;
 
       $clean = [];
-
       foreach ($fields as $field) {
-        if (empty($field['id'])) {
-          continue;
-        }
+        if (empty($field['id'])) continue;
 
-        $id = $field['id'];
+        $id   = $field['id'];
         $type = isset($field['type']) ? $field['type'] : 'text';
-        $raw = isset($item[$id]) ? $item[$id] : '';
+        $raw  = isset($item[$id]) ? $item[$id] : '';
 
         switch ($type) {
           case 'textarea':
@@ -170,7 +122,7 @@ if (!function_exists('figma_rebuild_sanitize_repeater')) {
             $clean[$id] = esc_url_raw($raw);
             break;
           case 'date':
-            $timestamp = strtotime((string) $raw);
+            $timestamp  = strtotime((string) $raw);
             $clean[$id] = $timestamp ? gmdate('Y-m-d', $timestamp) : '';
             break;
           default:
@@ -179,16 +131,9 @@ if (!function_exists('figma_rebuild_sanitize_repeater')) {
         }
       }
 
-      // Skip items where every field is empty.
-      if (empty(array_filter($clean, function ($value) {
-        return '' !== trim((string) $value);
-      }))) {
-        continue;
-      }
-
+      if (empty(array_filter($clean, function ($v) { return '' !== trim((string)$v); }))) continue;
       $sanitized[] = $clean;
     }
-
     return wp_json_encode(array_values($sanitized));
   }
 }
@@ -266,17 +211,26 @@ if (!function_exists('figma_rebuild_get_default_news_items')) {
 }
 
 // Register Customizer settings for all theme sections
-
 add_action('customize_register', function ($wp_customize) {
-  $template_uri = get_template_directory_uri();
+  $template_uri       = get_template_directory_uri();
   $solutions_defaults = function_exists('figma_rebuild_get_solutions_defaults') ? figma_rebuild_get_solutions_defaults() : [];
 
+  /**
+   * NEW: Front Page master panel
+   */
+  $wp_customize->add_panel('front_page_panel', [
+    'title'       => __('Front Page', 'figma-rebuild'),
+    'priority'    => 25,
+    'description' => __('Configure all sections of the site homepage in one place.', 'figma-rebuild'),
+  ]);
+
   /* ------------------------------------------------------------------------ */
-  /* Hero Section                                                             */
+  /* Hero Section  (moved under front_page_panel)                             */
   /* ------------------------------------------------------------------------ */
   $wp_customize->add_section('hero_section', [
-    'title'       => __('Hero Section', 'figma-rebuild'),
+    'title'       => __('Hero', 'figma-rebuild'),
     'priority'    => 30,
+    'panel'       => 'front_page_panel',
     'description' => __('设置首页 Hero 区域的标题、副标题和段落。', 'figma-rebuild'),
   ]);
 
@@ -318,13 +272,11 @@ add_action('customize_register', function ($wp_customize) {
     'hero_bg_image_2' => $template_uri . '/src/images/bg_house2.jpg',
     'hero_bg_image_3' => $template_uri . '/src/images/bg_forest.jpg',
   ];
-
   foreach ($hero_background_defaults as $setting_id => $default) {
     $wp_customize->add_setting($setting_id, [
       'default'           => $default,
       'sanitize_callback' => 'esc_url_raw',
     ]);
-
     $wp_customize->add_control(new WP_Customize_Image_Control(
       $wp_customize,
       $setting_id,
@@ -336,11 +288,12 @@ add_action('customize_register', function ($wp_customize) {
   }
 
   /* ------------------------------------------------------------------------ */
-  /* Why Us Section                                                           */
+  /* Why Us Section  (moved under front_page_panel)                           */
   /* ------------------------------------------------------------------------ */
   $wp_customize->add_section('whyus_section', [
-    'title'    => __('Why Us Section', 'figma-rebuild'),
+    'title'    => __('Why Us', 'figma-rebuild'),
     'priority' => 35,
+    'panel'    => 'front_page_panel',
   ]);
 
   $wp_customize->add_setting('whyus_title', [
@@ -397,11 +350,12 @@ add_action('customize_register', function ($wp_customize) {
   ));
 
   /* ------------------------------------------------------------------------ */
-  /* Services Section                                                         */
+  /* Services Section  (moved under front_page_panel)                         */
   /* ------------------------------------------------------------------------ */
   $wp_customize->add_section('services_section', [
-    'title'    => __('Services Section', 'figma-rebuild'),
+    'title'    => __('Services', 'figma-rebuild'),
     'priority' => 40,
+    'panel'    => 'front_page_panel',
   ]);
 
   $wp_customize->add_setting('services_title', [
@@ -452,7 +406,6 @@ add_action('customize_register', function ($wp_customize) {
       'image_label'   => __('Home Energy 图片', 'figma-rebuild'),
     ],
   ];
-
   foreach ($services_cards as $prefix => $card) {
     $title_setting = $prefix . '_title';
     $image_setting = $prefix . '_image';
@@ -483,11 +436,12 @@ add_action('customize_register', function ($wp_customize) {
   }
 
   /* ------------------------------------------------------------------------ */
-  /* Monitor Section                                                          */
+  /* Monitor Section  (moved under front_page_panel)                          */
   /* ------------------------------------------------------------------------ */
   $wp_customize->add_section('monitor_section', [
-    'title'    => __('Monitor Section', 'figma-rebuild'),
+    'title'    => __('Monitor', 'figma-rebuild'),
     'priority' => 45,
+    'panel'    => 'front_page_panel',
   ]);
 
   $wp_customize->add_setting('monitor_title', [
@@ -577,11 +531,12 @@ add_action('customize_register', function ($wp_customize) {
   ));
 
   /* ------------------------------------------------------------------------ */
-  /* Trust Section                                                            */
+  /* Trust Section  (moved under front_page_panel)                            */
   /* ------------------------------------------------------------------------ */
   $wp_customize->add_section('trust_section', [
-    'title'    => __('Trust Section', 'figma-rebuild'),
+    'title'    => __('Trust', 'figma-rebuild'),
     'priority' => 50,
+    'panel'    => 'front_page_panel',
   ]);
 
   $wp_customize->add_setting('trust_title', [
@@ -618,18 +573,16 @@ add_action('customize_register', function ($wp_customize) {
   ));
 
   $testimonial_fields = [
-    ['id' => 'title', 'label' => __('标题', 'figma-rebuild'), 'type' => 'text'],
-    ['id' => 'body', 'label' => __('内容', 'figma-rebuild'), 'type' => 'textarea'],
+    ['id' => 'title',  'label' => __('标题', 'figma-rebuild'), 'type' => 'text'],
+    ['id' => 'body',   'label' => __('内容', 'figma-rebuild'), 'type' => 'textarea'],
     ['id' => 'author', 'label' => __('署名', 'figma-rebuild'), 'type' => 'text'],
   ];
-
   $wp_customize->add_setting('trust_testimonials', [
     'default'           => wp_json_encode(figma_rebuild_get_default_testimonials()),
     'sanitize_callback' => function ($input) use ($testimonial_fields) {
       return figma_rebuild_sanitize_repeater($input, $testimonial_fields);
     },
   ]);
-
   $wp_customize->add_control(new Figma_Rebuild_Repeater_Control(
     $wp_customize,
     'trust_testimonials',
@@ -644,16 +597,14 @@ add_action('customize_register', function ($wp_customize) {
 
   $partner_fields = [
     ['id' => 'label', 'label' => __('合作伙伴名称', 'figma-rebuild'), 'type' => 'text'],
-    ['id' => 'logo', 'label' => __('Logo 图片地址（可选）', 'figma-rebuild'), 'type' => 'url'],
+    ['id' => 'logo',  'label' => __('Logo 图片地址（可选）', 'figma-rebuild'), 'type' => 'url'],
   ];
-
   $wp_customize->add_setting('trust_partners', [
     'default'           => wp_json_encode(figma_rebuild_get_default_partners()),
     'sanitize_callback' => function ($input) use ($partner_fields) {
       return figma_rebuild_sanitize_repeater($input, $partner_fields);
     },
   ]);
-
   $wp_customize->add_control(new Figma_Rebuild_Repeater_Control(
     $wp_customize,
     'trust_partners',
@@ -667,11 +618,12 @@ add_action('customize_register', function ($wp_customize) {
   ));
 
   /* ------------------------------------------------------------------------ */
-  /* News Section                                                             */
+  /* News Section  (moved under front_page_panel)                             */
   /* ------------------------------------------------------------------------ */
   $wp_customize->add_section('news_section', [
-    'title'    => __('News Section', 'figma-rebuild'),
+    'title'    => __('News', 'figma-rebuild'),
     'priority' => 55,
+    'panel'    => 'front_page_panel',
   ]);
 
   $wp_customize->add_setting('news_title', [
@@ -710,19 +662,17 @@ add_action('customize_register', function ($wp_customize) {
 
   $news_fields = [
     ['id' => 'title', 'label' => __('文章标题', 'figma-rebuild'), 'type' => 'text'],
-    ['id' => 'tag', 'label' => __('标签', 'figma-rebuild'), 'type' => 'text'],
-    ['id' => 'date', 'label' => __('日期 (YYYY-MM-DD)', 'figma-rebuild'), 'type' => 'date'],
+    ['id' => 'tag',   'label' => __('标签', 'figma-rebuild'),     'type' => 'text'],
+    ['id' => 'date',  'label' => __('日期 (YYYY-MM-DD)', 'figma-rebuild'), 'type' => 'date'],
     ['id' => 'image', 'label' => __('封面图片地址', 'figma-rebuild'), 'type' => 'url'],
-    ['id' => 'link', 'label' => __('链接（可选）', 'figma-rebuild'), 'type' => 'url'],
+    ['id' => 'link',  'label' => __('链接（可选）', 'figma-rebuild'), 'type' => 'url'],
   ];
-
   $wp_customize->add_setting('news_items', [
     'default'           => wp_json_encode(figma_rebuild_get_default_news_items()),
     'sanitize_callback' => function ($input) use ($news_fields) {
       return figma_rebuild_sanitize_repeater($input, $news_fields);
     },
   ]);
-
   $wp_customize->add_control(new Figma_Rebuild_Repeater_Control(
     $wp_customize,
     'news_items',
@@ -735,6 +685,9 @@ add_action('customize_register', function ($wp_customize) {
     ]
   ));
 
+  /* ------------------------------------------------------------------------ */
+  /* Solutions Page (existing, unchanged, stays under its own panel)          */
+  /* ------------------------------------------------------------------------ */
   if (!empty($solutions_defaults)) {
     $wp_customize->add_panel('solutions_panel', [
       'title'       => __('Solutions Page', 'figma-rebuild'),
@@ -742,16 +695,12 @@ add_action('customize_register', function ($wp_customize) {
       'description' => __('Configure the dedicated Solutions landing page sections.', 'figma-rebuild'),
     ]);
 
-    /* -------------------------------------------------------------------- */
-    /* Solutions Hero                                                       */
-    /* -------------------------------------------------------------------- */
+    // Solutions Hero
     $hero_defaults = isset($solutions_defaults['hero']) ? $solutions_defaults['hero'] : [];
-
     $wp_customize->add_section('solutions_hero_section', [
       'title' => __('Hero', 'figma-rebuild'),
       'panel' => 'solutions_panel',
     ]);
-
     $wp_customize->add_setting('solutions_hero_title', [
       'default'           => isset($hero_defaults['title']) ? $hero_defaults['title'] : '',
       'sanitize_callback' => 'sanitize_text_field',
@@ -761,7 +710,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_hero_section',
       'type'    => 'text',
     ]);
-
     $wp_customize->add_setting('solutions_hero_headline', [
       'default'           => isset($hero_defaults['headline']) ? $hero_defaults['headline'] : '',
       'sanitize_callback' => 'sanitize_text_field',
@@ -771,7 +719,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_hero_section',
       'type'    => 'text',
     ]);
-
     $wp_customize->add_setting('solutions_hero_description', [
       'default'           => isset($hero_defaults['description']) ? $hero_defaults['description'] : '',
       'sanitize_callback' => 'wp_kses_post',
@@ -781,7 +728,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_hero_section',
       'type'    => 'textarea',
     ]);
-
     $wp_customize->add_setting('solutions_hero_background', [
       'default'           => isset($hero_defaults['background']) ? $hero_defaults['background'] : '',
       'sanitize_callback' => 'esc_url_raw',
@@ -795,16 +741,12 @@ add_action('customize_register', function ($wp_customize) {
       ]
     ));
 
-    /* -------------------------------------------------------------------- */
-    /* Service Chooser                                                      */
-    /* -------------------------------------------------------------------- */
+    // Service Navigator
     $services_defaults = isset($solutions_defaults['services']) ? $solutions_defaults['services'] : [];
-
     $wp_customize->add_section('solutions_services_section', [
       'title' => __('Service Navigator', 'figma-rebuild'),
       'panel' => 'solutions_panel',
     ]);
-
     $wp_customize->add_setting('solutions_services_title', [
       'default'           => isset($services_defaults['title']) ? $services_defaults['title'] : '',
       'sanitize_callback' => 'sanitize_text_field',
@@ -814,7 +756,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_services_section',
       'type'    => 'text',
     ]);
-
     $wp_customize->add_setting('solutions_services_description', [
       'default'           => isset($services_defaults['description']) ? $services_defaults['description'] : '',
       'sanitize_callback' => 'wp_kses_post',
@@ -826,21 +767,19 @@ add_action('customize_register', function ($wp_customize) {
     ]);
 
     $service_fields = [
-      ['id' => 'label', 'label' => __('Badge label', 'figma-rebuild'), 'type' => 'text'],
-      ['id' => 'title', 'label' => __('Card title', 'figma-rebuild'), 'type' => 'text'],
+      ['id' => 'label',       'label' => __('Badge label', 'figma-rebuild'), 'type' => 'text'],
+      ['id' => 'title',       'label' => __('Card title', 'figma-rebuild'),  'type' => 'text'],
       ['id' => 'description', 'label' => __('Description', 'figma-rebuild'), 'type' => 'textarea'],
-      ['id' => 'image', 'label' => __('Image URL', 'figma-rebuild'), 'type' => 'url'],
-      ['id' => 'link_label', 'label' => __('Link label', 'figma-rebuild'), 'type' => 'text'],
-      ['id' => 'link_url', 'label' => __('Link URL', 'figma-rebuild'), 'type' => 'url'],
+      ['id' => 'image',       'label' => __('Image URL', 'figma-rebuild'),   'type' => 'url'],
+      ['id' => 'link_label',  'label' => __('Link label', 'figma-rebuild'),  'type' => 'text'],
+      ['id' => 'link_url',    'label' => __('Link URL', 'figma-rebuild'),    'type' => 'url'],
     ];
-
     $wp_customize->add_setting('solutions_services_items', [
       'default'           => isset($services_defaults['items']) ? wp_json_encode($services_defaults['items']) : wp_json_encode([]),
       'sanitize_callback' => function ($input) use ($service_fields) {
         return figma_rebuild_sanitize_repeater($input, $service_fields);
       },
     ]);
-
     $wp_customize->add_control(new Figma_Rebuild_Repeater_Control(
       $wp_customize,
       'solutions_services_items',
@@ -853,21 +792,17 @@ add_action('customize_register', function ($wp_customize) {
       ]
     ));
 
-    /* -------------------------------------------------------------------- */
-    /* Detail Sections (Home, Commercial, Fleet)                             */
-    /* -------------------------------------------------------------------- */
+    // Detail Sections (Home, Commercial, Fleet)
     $solutions_detail_sections = [
-      'home'        => __('Home Section', 'figma-rebuild'),
-      'commercial'  => __('Commercial Section', 'figma-rebuild'),
-      'fleet'       => __('Fleet Section', 'figma-rebuild'),
+      'home'       => __('Home Section', 'figma-rebuild'),
+      'commercial' => __('Commercial Section', 'figma-rebuild'),
+      'fleet'      => __('Fleet Section', 'figma-rebuild'),
     ];
-
     $feature_fields = [
       ['id' => 'text', 'label' => __('Feature text', 'figma-rebuild'), 'type' => 'text'],
     ];
-
     foreach ($solutions_detail_sections as $key => $label) {
-      $defaults = isset($solutions_defaults[$key]) ? $solutions_defaults[$key] : [];
+      $defaults   = isset($solutions_defaults[$key]) ? $solutions_defaults[$key] : [];
       $section_id = 'solutions_' . $key . '_section';
 
       $wp_customize->add_section($section_id, [
@@ -987,16 +922,12 @@ add_action('customize_register', function ($wp_customize) {
       ));
     }
 
-    /* -------------------------------------------------------------------- */
-    /* ZEVIP Program                                                         */
-    /* -------------------------------------------------------------------- */
+    // ZEVIP Program
     $zevip_defaults = isset($solutions_defaults['zevip']) ? $solutions_defaults['zevip'] : [];
-
     $wp_customize->add_section('solutions_zevip_section', [
       'title' => __('ZEVIP Program', 'figma-rebuild'),
       'panel' => 'solutions_panel',
     ]);
-
     $wp_customize->add_setting('solutions_zevip_heading', [
       'default'           => isset($zevip_defaults['heading']) ? $zevip_defaults['heading'] : '',
       'sanitize_callback' => 'sanitize_text_field',
@@ -1006,7 +937,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_zevip_section',
       'type'    => 'text',
     ]);
-
     $wp_customize->add_setting('solutions_zevip_intro', [
       'default'           => isset($zevip_defaults['intro']) ? $zevip_defaults['intro'] : '',
       'sanitize_callback' => 'wp_kses_post',
@@ -1016,7 +946,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_zevip_section',
       'type'    => 'textarea',
     ]);
-
     $wp_customize->add_setting('solutions_zevip_features', [
       'default'           => isset($zevip_defaults['features']) ? wp_json_encode($zevip_defaults['features']) : wp_json_encode([]),
       'sanitize_callback' => function ($input) use ($feature_fields) {
@@ -1034,7 +963,6 @@ add_action('customize_register', function ($wp_customize) {
         'item_label'       => __('Service', 'figma-rebuild'),
       ]
     ));
-
     $wp_customize->add_setting('solutions_zevip_button_text', [
       'default'           => isset($zevip_defaults['button_text']) ? $zevip_defaults['button_text'] : '',
       'sanitize_callback' => 'sanitize_text_field',
@@ -1044,7 +972,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_zevip_section',
       'type'    => 'text',
     ]);
-
     $wp_customize->add_setting('solutions_zevip_button_link', [
       'default'           => isset($zevip_defaults['button_link']) ? $zevip_defaults['button_link'] : '',
       'sanitize_callback' => 'esc_url_raw',
@@ -1054,7 +981,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_zevip_section',
       'type'    => 'url',
     ]);
-
     $wp_customize->add_setting('solutions_zevip_image', [
       'default'           => isset($zevip_defaults['image']) ? $zevip_defaults['image'] : '',
       'sanitize_callback' => 'esc_url_raw',
@@ -1068,16 +994,12 @@ add_action('customize_register', function ($wp_customize) {
       ]
     ));
 
-    /* -------------------------------------------------------------------- */
-    /* Contact / Book Section                                               */
-    /* -------------------------------------------------------------------- */
+    // Book / Contact
     $book_defaults = isset($solutions_defaults['book']) ? $solutions_defaults['book'] : [];
-
     $wp_customize->add_section('solutions_book_section', [
       'title' => __('Book a Consultation', 'figma-rebuild'),
       'panel' => 'solutions_panel',
     ]);
-
     $wp_customize->add_setting('solutions_book_title', [
       'default'           => isset($book_defaults['title']) ? $book_defaults['title'] : '',
       'sanitize_callback' => 'sanitize_text_field',
@@ -1087,7 +1009,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_book_section',
       'type'    => 'text',
     ]);
-
     $wp_customize->add_setting('solutions_book_description', [
       'default'           => isset($book_defaults['description']) ? $book_defaults['description'] : '',
       'sanitize_callback' => 'wp_kses_post',
@@ -1097,7 +1018,6 @@ add_action('customize_register', function ($wp_customize) {
       'section' => 'solutions_book_section',
       'type'    => 'textarea',
     ]);
-
     $wp_customize->add_setting('solutions_book_background', [
       'default'           => isset($book_defaults['background']) ? $book_defaults['background'] : '',
       'sanitize_callback' => 'esc_url_raw',
@@ -1110,21 +1030,18 @@ add_action('customize_register', function ($wp_customize) {
         'section' => 'solutions_book_section',
       ]
     ));
-
     $book_fields = [
-      ['id' => 'title', 'label' => __('Card title', 'figma-rebuild'), 'type' => 'text'],
+      ['id' => 'title',       'label' => __('Card title', 'figma-rebuild'),       'type' => 'text'],
       ['id' => 'description', 'label' => __('Card description', 'figma-rebuild'), 'type' => 'textarea'],
-      ['id' => 'cta_label', 'label' => __('CTA label', 'figma-rebuild'), 'type' => 'text'],
-      ['id' => 'cta_url', 'label' => __('CTA URL', 'figma-rebuild'), 'type' => 'url'],
+      ['id' => 'cta_label',   'label' => __('CTA label', 'figma-rebuild'),        'type' => 'text'],
+      ['id' => 'cta_url',     'label' => __('CTA URL', 'figma-rebuild'),          'type' => 'url'],
     ];
-
     $wp_customize->add_setting('solutions_book_cards', [
       'default'           => isset($book_defaults['cards']) ? wp_json_encode($book_defaults['cards']) : wp_json_encode([]),
       'sanitize_callback' => function ($input) use ($book_fields) {
         return figma_rebuild_sanitize_repeater($input, $book_fields);
       },
     ]);
-
     $wp_customize->add_control(new Figma_Rebuild_Repeater_Control(
       $wp_customize,
       'solutions_book_cards',
@@ -1166,5 +1083,3 @@ add_action('customize_controls_enqueue_scripts', function () {
     file_exists(get_template_directory() . '/assets/css/customizer-controls.css') ? filemtime(get_template_directory() . '/assets/css/customizer-controls.css') : null
   );
 });
-
-

--- a/inc/solutions.php
+++ b/inc/solutions.php
@@ -211,11 +211,19 @@ if (!function_exists('figma_rebuild_get_solutions_page_url')) {
     }
 
     if (!$solutions_page instanceof WP_Post) {
-      $solutions_page = get_page_by_path('solutions');
+      $candidate_page = get_page_by_path('solutions');
+
+      if ($candidate_page instanceof WP_Post && 'publish' === get_post_status($candidate_page->ID)) {
+        $solutions_page = $candidate_page;
+      }
     }
 
     if (!$solutions_page instanceof WP_Post) {
-      $solutions_page = get_page_by_title('Solutions');
+      $candidate_page = get_page_by_title('Solutions');
+
+      if ($candidate_page instanceof WP_Post && 'publish' === get_post_status($candidate_page->ID)) {
+        $solutions_page = $candidate_page;
+      }
     }
 
     if ($solutions_page instanceof WP_Post) {
@@ -228,8 +236,6 @@ if (!function_exists('figma_rebuild_get_solutions_page_url')) {
       }
     }
 
-    $cached_url = '#solutions';
-
-    return $cached_url;
+    return home_url('/solutions/');
   }
 }

--- a/inc/solutions.php
+++ b/inc/solutions.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Solutions page helper defaults and utilities.
+ */
+
+if (!function_exists('figma_rebuild_get_solutions_defaults')) {
+  /**
+   * Provide default content for the Solutions page sections.
+   *
+   * @return array
+   */
+  function figma_rebuild_get_solutions_defaults() {
+    $template_uri = get_template_directory_uri();
+
+    return [
+      'hero'      => [
+        'title'       => __('Solutions', 'figma-rebuild'),
+        'headline'    => __('Maxperr, Canada\'s EV specialists.', 'figma-rebuild'),
+        'description' => __('Discover tailored charging solutions for every application—from single family homes to complex multi-site fleets. Our experts design, install, and maintain EV infrastructure that keeps you powered and compliant.', 'figma-rebuild'),
+        'background'  => $template_uri . '/src/images/bg_house2.jpg',
+      ],
+      'services'  => [
+        'title'       => __('What service do I need?', 'figma-rebuild'),
+        'description' => __('Select the path that matches your project and see how Maxperr delivers safe, reliable charging across residential, commercial, and funded deployments.', 'figma-rebuild'),
+        'items'       => [
+          [
+            'label'       => __('Home Charging', 'figma-rebuild'),
+            'title'       => __('Residential solutions', 'figma-rebuild'),
+            'description' => __('Level 2 chargers, permitting, and white-glove installation services made for Canadian homes.', 'figma-rebuild'),
+            'image'       => 'https://images.unsplash.com/photo-1617813489478-62d083d70a75?auto=format&fit=crop&w=800&q=80',
+            'link_label'  => __('Explore home', 'figma-rebuild'),
+            'link_url'    => '#solutions-home',
+          ],
+          [
+            'label'       => __('Commercial', 'figma-rebuild'),
+            'title'       => __('Workplace & retail', 'figma-rebuild'),
+            'description' => __('Turn-key charging programs for offices, mixed-use buildings, and public destinations.', 'figma-rebuild'),
+            'image'       => 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=800&q=80',
+            'link_label'  => __('Explore commercial', 'figma-rebuild'),
+            'link_url'    => '#solutions-commercial',
+          ],
+          [
+            'label'       => __('Fleet', 'figma-rebuild'),
+            'title'       => __('Fleet electrification', 'figma-rebuild'),
+            'description' => __('Scalable AC/DC infrastructure, depot design, and energy management for fleet operators.', 'figma-rebuild'),
+            'image'       => 'https://images.unsplash.com/photo-1625480864588-23a57dc3884b?auto=format&fit=crop&w=800&q=80',
+            'link_label'  => __('Explore fleet', 'figma-rebuild'),
+            'link_url'    => '#solutions-fleet',
+          ],
+          [
+            'label'       => __('ZEVIP Funding', 'figma-rebuild'),
+            'title'       => __('Funding guidance', 'figma-rebuild'),
+            'description' => __('Strategic support to navigate Natural Resources Canada\'s incentive program and secure rebates.', 'figma-rebuild'),
+            'image'       => 'https://images.unsplash.com/photo-1509391366360-2e959784a276?auto=format&fit=crop&w=800&q=80',
+            'link_label'  => __('Explore ZEVIP', 'figma-rebuild'),
+            'link_url'    => '#solutions-zevip',
+          ],
+        ],
+      ],
+      'home'      => [
+        'heading'     => __('Home', 'figma-rebuild'),
+        'intro'       => __('Perfect for homeowners seeking reliable, code-compliant Level 2 charging with professional installation and monitoring.', 'figma-rebuild'),
+        'badge'       => __('Home', 'figma-rebuild'),
+        'card_title'  => __('Eco Home EV Charger', 'figma-rebuild'),
+        'card_body'   => __('Maxperr bundles hardware, permitting, and support so you never have to worry about charging at home.', 'figma-rebuild'),
+        'features'    => [
+          ['text' => __('Home Power Bundle', 'figma-rebuild')],
+          ['text' => __('Smart monitoring app', 'figma-rebuild')],
+          ['text' => __('CSA & ESA certified installers', 'figma-rebuild')],
+        ],
+        'note'        => __('Best for detached and semi-detached homes across Canada.', 'figma-rebuild'),
+        'button_text' => __('Book a home visit', 'figma-rebuild'),
+        'button_link' => '#contact',
+        'image'       => 'https://images.unsplash.com/photo-1617813489264-6a508a403ef2?auto=format&fit=crop&w=900&q=80',
+      ],
+      'commercial' => [
+        'heading'     => __('Commercial', 'figma-rebuild'),
+        'intro'       => __('Support tenant retention, attract EV drivers, and monetize charging across mixed-use properties.', 'figma-rebuild'),
+        'badge'       => __('Commercial', 'figma-rebuild'),
+        'card_title'  => __('Smart 30kW DC Charger', 'figma-rebuild'),
+        'card_body'   => __('Designed for multi-unit residential buildings, workplaces, and retail locations needing fast turnaround.', 'figma-rebuild'),
+        'features'    => [
+          ['text' => __('Load balancing & demand response', 'figma-rebuild')],
+          ['text' => __('Revenue-grade energy metering', 'figma-rebuild')],
+          ['text' => __('24/7 remote operations center', 'figma-rebuild')],
+        ],
+        'note'        => __('Ideal for property managers and developers planning mixed-access charging.', 'figma-rebuild'),
+        'button_text' => __('Plan your site', 'figma-rebuild'),
+        'button_link' => '#contact',
+        'image'       => 'https://images.unsplash.com/photo-1529429617124-aee711f6a1c9?auto=format&fit=crop&w=900&q=80',
+      ],
+      'fleet'     => [
+        'heading'     => __('Fleet', 'figma-rebuild'),
+        'intro'       => __('Engineer dependable depot charging with smart scheduling, peak shaving, and lifecycle support.', 'figma-rebuild'),
+        'badge'       => __('Fleet', 'figma-rebuild'),
+        'card_title'  => __('Pro 180kW DC Charger', 'figma-rebuild'),
+        'card_body'   => __('Transition light-, medium-, and heavy-duty vehicles with modular DC fast charging and software integrations.', 'figma-rebuild'),
+        'features'    => [
+          ['text' => __('Depot energy modelling', 'figma-rebuild')],
+          ['text' => __('Charging management platform', 'figma-rebuild')],
+          ['text' => __('Preventive maintenance programs', 'figma-rebuild')],
+        ],
+        'note'        => __('Supports fleet yards, logistics hubs, and municipal operations.', 'figma-rebuild'),
+        'button_text' => __('Talk to fleet experts', 'figma-rebuild'),
+        'button_link' => '#contact',
+        'image'       => 'https://images.unsplash.com/photo-1617813489622-95823483363d?auto=format&fit=crop&w=900&q=80',
+      ],
+      'zevip'     => [
+        'heading'     => __('Zero Emission Vehicle Infrastructure Program (ZEVIP)', 'figma-rebuild'),
+        'intro'       => __('Maxperr helps Canadian businesses maximize Natural Resources Canada rebates with turnkey project development and grant writing support.', 'figma-rebuild'),
+        'features'    => [
+          ['text' => __('Grant intake strategy & application support', 'figma-rebuild')],
+          ['text' => __('Engineering drawings & budgetary planning', 'figma-rebuild')],
+          ['text' => __('Measurement & verification reporting', 'figma-rebuild')],
+        ],
+        'button_text' => __('Download the ZEVIP guide', 'figma-rebuild'),
+        'button_link' => '#',
+        'image'       => 'https://images.unsplash.com/photo-1470246973918-29a93221c455?auto=format&fit=crop&w=1000&q=80',
+      ],
+      'book'      => [
+        'title'       => __('Want more details?', 'figma-rebuild'),
+        'description' => __('Connect with our specialists to scope your project, secure incentives, and schedule installation timelines.', 'figma-rebuild'),
+        'background'  => $template_uri . '/src/images/bg_forest.jpg',
+        'cards'       => [
+          [
+            'title'       => __('Sales Inquiries', 'figma-rebuild'),
+            'description' => __('Work with our consultants to scope equipment, installation, and funding options tailored to your site.', 'figma-rebuild'),
+            'cta_label'   => __('sales@maxperr.com', 'figma-rebuild'),
+            'cta_url'     => 'mailto:sales@maxperr.com',
+          ],
+          [
+            'title'       => __('Technical Support', 'figma-rebuild'),
+            'description' => __('Get help with commissioning, software onboarding, and preventative maintenance scheduling.', 'figma-rebuild'),
+            'cta_label'   => __('1-800-000-0000', 'figma-rebuild'),
+            'cta_url'     => 'tel:18000000000',
+          ],
+        ],
+      ],
+    ];
+  }
+}
+
+if (!function_exists('figma_rebuild_get_repeater_mod')) {
+  /**
+   * Retrieve and decode a JSON repeater theme mod.
+   *
+   * @param string $setting Setting key.
+   * @param array  $default Default array of values.
+   *
+   * @return array
+   */
+  function figma_rebuild_get_repeater_mod($setting, $default = []) {
+    $raw = get_theme_mod($setting, wp_json_encode($default));
+
+    if (is_array($raw)) {
+      $decoded = $raw;
+    } elseif (is_string($raw)) {
+      $decoded = json_decode($raw, true);
+    } else {
+      $decoded = [];
+    }
+
+    if (!is_array($decoded)) {
+      return [];
+    }
+
+    return array_values(array_filter($decoded, function ($item) {
+      if (!is_array($item)) {
+        return false;
+      }
+
+      foreach ($item as $value) {
+        if ('' !== trim((string) $value)) {
+          return true;
+        }
+      }
+
+      return false;
+    }));
+  }
+}

--- a/inc/solutions.php
+++ b/inc/solutions.php
@@ -179,3 +179,57 @@ if (!function_exists('figma_rebuild_get_repeater_mod')) {
     }));
   }
 }
+
+if (!function_exists('figma_rebuild_get_solutions_page_url')) {
+  /**
+   * Locate the permalink for the published Solutions page.
+   *
+   * @return string
+   */
+  function figma_rebuild_get_solutions_page_url() {
+    static $cached_url = null;
+
+    if (null !== $cached_url) {
+      return $cached_url;
+    }
+
+    $solutions_page = null;
+
+    $template_pages = get_posts([
+      'post_type'      => 'page',
+      'post_status'    => 'publish',
+      'posts_per_page' => 1,
+      'meta_key'       => '_wp_page_template',
+      'meta_value'     => 'templates/page-solutions.php',
+      'orderby'        => 'menu_order',
+      'order'          => 'ASC',
+      'no_found_rows'  => true,
+    ]);
+
+    if (!empty($template_pages)) {
+      $solutions_page = $template_pages[0];
+    }
+
+    if (!$solutions_page instanceof WP_Post) {
+      $solutions_page = get_page_by_path('solutions');
+    }
+
+    if (!$solutions_page instanceof WP_Post) {
+      $solutions_page = get_page_by_title('Solutions');
+    }
+
+    if ($solutions_page instanceof WP_Post) {
+      $permalink = get_permalink($solutions_page);
+
+      if ($permalink) {
+        $cached_url = $permalink;
+
+        return $cached_url;
+      }
+    }
+
+    $cached_url = '#solutions';
+
+    return $cached_url;
+  }
+}

--- a/parts/solutions/book.php
+++ b/parts/solutions/book.php
@@ -1,0 +1,92 @@
+<?php
+  $defaults = function_exists('figma_rebuild_get_solutions_defaults') ? figma_rebuild_get_solutions_defaults() : [];
+  $book_defaults = isset($defaults['book']) ? $defaults['book'] : [];
+
+  $title = get_theme_mod('solutions_book_title', isset($book_defaults['title']) ? $book_defaults['title'] : '');
+  $description = get_theme_mod('solutions_book_description', isset($book_defaults['description']) ? $book_defaults['description'] : '');
+  $background = get_theme_mod('solutions_book_background', isset($book_defaults['background']) ? $book_defaults['background'] : '');
+  $cards = function_exists('figma_rebuild_get_repeater_mod')
+    ? figma_rebuild_get_repeater_mod('solutions_book_cards', isset($book_defaults['cards']) ? $book_defaults['cards'] : [])
+    : [];
+?>
+
+<section class="relative isolate overflow-hidden bg-slate-900 py-24" id="solutions-contact">
+  <?php if (!empty($background)) : ?>
+    <div class="absolute inset-0">
+      <img src="<?php echo esc_url($background); ?>" alt="" class="h-full w-full object-cover" loading="lazy" />
+      <div class="absolute inset-0 bg-slate-900/80"></div>
+    </div>
+  <?php endif; ?>
+
+  <div class="relative mx-auto max-w-6xl px-4 sm:px-6">
+    <div class="grid gap-10 lg:grid-cols-[1.1fr_1fr] lg:items-start">
+      <div class="space-y-6">
+        <?php if (!empty($title)) : ?>
+          <h2 class="text-3xl font-semibold text-white md:text-4xl">
+            <?php echo esc_html($title); ?>
+          </h2>
+        <?php endif; ?>
+
+        <?php if (!empty($description)) : ?>
+          <p class="text-lg leading-relaxed text-gray-200">
+            <?php echo wp_kses_post($description); ?>
+          </p>
+        <?php endif; ?>
+
+        <div class="mt-6 inline-flex flex-wrap gap-3 text-sm text-gray-300">
+          <span class="rounded-full border border-white/15 px-4 py-2">
+            <?php esc_html_e('Consulting', 'figma-rebuild'); ?>
+          </span>
+          <span class="rounded-full border border-white/15 px-4 py-2">
+            <?php esc_html_e('Deployment', 'figma-rebuild'); ?>
+          </span>
+          <span class="rounded-full border border-white/15 px-4 py-2">
+            <?php esc_html_e('Support', 'figma-rebuild'); ?>
+          </span>
+        </div>
+      </div>
+
+      <?php if (!empty($cards)) : ?>
+        <div class="grid gap-6 sm:grid-cols-2">
+          <?php foreach ($cards as $card) :
+            $card_title = isset($card['title']) ? $card['title'] : '';
+            $card_description = isset($card['description']) ? $card['description'] : '';
+            $card_cta_label = isset($card['cta_label']) ? $card['cta_label'] : '';
+            $card_cta_url = isset($card['cta_url']) ? $card['cta_url'] : '';
+          ?>
+            <div class="flex h-full flex-col gap-4 rounded-3xl bg-white/95 p-6 shadow-[0_35px_80px_-40px_rgba(15,23,42,0.45)] backdrop-blur">
+              <?php if (!empty($card_title)) : ?>
+                <h3 class="text-lg font-semibold text-slate-900">
+                  <?php echo esc_html($card_title); ?>
+                </h3>
+              <?php endif; ?>
+
+              <?php if (!empty($card_description)) : ?>
+                <p class="text-sm leading-relaxed text-gray-600">
+                  <?php echo wp_kses_post($card_description); ?>
+                </p>
+              <?php endif; ?>
+
+              <?php if (!empty($card_cta_label)) : ?>
+                <div class="mt-auto pt-2">
+                  <?php if (!empty($card_cta_url)) : ?>
+                    <a href="<?php echo esc_url($card_cta_url); ?>" class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-primary-dark">
+                      <?php echo esc_html($card_cta_label); ?>
+                      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path d="M5 10h8m0 0-3-3m3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                    </a>
+                  <?php else : ?>
+                    <span class="text-sm font-semibold text-slate-900">
+                      <?php echo esc_html($card_cta_label); ?>
+                    </span>
+                  <?php endif; ?>
+                </div>
+              <?php endif; ?>
+            </div>
+          <?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+</section>

--- a/parts/solutions/hero.php
+++ b/parts/solutions/hero.php
@@ -1,0 +1,39 @@
+<?php
+  $defaults = function_exists('figma_rebuild_get_solutions_defaults') ? figma_rebuild_get_solutions_defaults() : [];
+  $hero_defaults = isset($defaults['hero']) ? $defaults['hero'] : [];
+
+  $title = get_theme_mod('solutions_hero_title', isset($hero_defaults['title']) ? $hero_defaults['title'] : '');
+  $headline = get_theme_mod('solutions_hero_headline', isset($hero_defaults['headline']) ? $hero_defaults['headline'] : '');
+  $description = get_theme_mod('solutions_hero_description', isset($hero_defaults['description']) ? $hero_defaults['description'] : '');
+  $background = get_theme_mod('solutions_hero_background', isset($hero_defaults['background']) ? $hero_defaults['background'] : '');
+?>
+
+<section class="relative isolate overflow-hidden bg-slate-900" id="solutions-hero">
+  <?php if (!empty($background)) : ?>
+    <div class="absolute inset-0">
+      <img src="<?php echo esc_url($background); ?>" alt="" class="h-full w-full object-cover" loading="lazy" />
+      <div class="absolute inset-0 bg-slate-900/70 mix-blend-multiply"></div>
+      <div class="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-slate-900"></div>
+    </div>
+  <?php endif; ?>
+
+  <div class="relative mx-auto flex max-w-6xl flex-col gap-6 px-4 py-24 sm:px-6 md:py-28 lg:py-32">
+    <?php if (!empty($title)) : ?>
+      <span class="inline-flex w-fit items-center rounded-full bg-white/10 px-4 py-1 text-sm font-semibold uppercase tracking-[0.2em] text-primary-light backdrop-blur">
+        <?php echo esc_html($title); ?>
+      </span>
+    <?php endif; ?>
+
+    <?php if (!empty($headline)) : ?>
+      <h1 class="text-4xl font-semibold leading-tight text-white md:text-5xl lg:text-[56px] lg:leading-[1.05]">
+        <?php echo esc_html($headline); ?>
+      </h1>
+    <?php endif; ?>
+
+    <?php if (!empty($description)) : ?>
+      <p class="max-w-3xl text-lg leading-relaxed text-gray-200">
+        <?php echo wp_kses_post($description); ?>
+      </p>
+    <?php endif; ?>
+  </div>
+</section>

--- a/parts/solutions/section.php
+++ b/parts/solutions/section.php
@@ -1,0 +1,109 @@
+<?php
+  $section_key = isset($args['section']) ? $args['section'] : 'home';
+  $layout = isset($args['layout']) ? $args['layout'] : 'image-left';
+  $is_image_right = ('image-right' === $layout);
+
+  $defaults = function_exists('figma_rebuild_get_solutions_defaults') ? figma_rebuild_get_solutions_defaults() : [];
+  $section_defaults = isset($defaults[$section_key]) ? $defaults[$section_key] : [];
+
+  $heading = get_theme_mod('solutions_' . $section_key . '_heading', isset($section_defaults['heading']) ? $section_defaults['heading'] : '');
+  $intro = get_theme_mod('solutions_' . $section_key . '_intro', isset($section_defaults['intro']) ? $section_defaults['intro'] : '');
+  $badge = get_theme_mod('solutions_' . $section_key . '_badge', isset($section_defaults['badge']) ? $section_defaults['badge'] : '');
+  $card_title = get_theme_mod('solutions_' . $section_key . '_card_title', isset($section_defaults['card_title']) ? $section_defaults['card_title'] : '');
+  $card_body = get_theme_mod('solutions_' . $section_key . '_card_body', isset($section_defaults['card_body']) ? $section_defaults['card_body'] : '');
+  $note = get_theme_mod('solutions_' . $section_key . '_note', isset($section_defaults['note']) ? $section_defaults['note'] : '');
+  $button_text = get_theme_mod('solutions_' . $section_key . '_button_text', isset($section_defaults['button_text']) ? $section_defaults['button_text'] : '');
+  $button_link = get_theme_mod('solutions_' . $section_key . '_button_link', isset($section_defaults['button_link']) ? $section_defaults['button_link'] : '');
+  $image = get_theme_mod('solutions_' . $section_key . '_image', isset($section_defaults['image']) ? $section_defaults['image'] : '');
+
+  $features = function_exists('figma_rebuild_get_repeater_mod')
+    ? figma_rebuild_get_repeater_mod('solutions_' . $section_key . '_features', isset($section_defaults['features']) ? $section_defaults['features'] : [])
+    : [];
+
+  $section_id = 'solutions-' . sanitize_title($section_key);
+?>
+
+<section class="bg-white py-20" id="<?php echo esc_attr($section_id); ?>">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
+    <div class="flex flex-col gap-12 lg:gap-16 lg:items-center <?php echo $is_image_right ? 'lg:flex-row-reverse' : 'lg:flex-row'; ?>">
+      <div class="w-full flex-1 space-y-8">
+        <?php if (!empty($heading)) : ?>
+          <div class="space-y-3">
+            <h2 class="text-3xl font-semibold text-slate-900 md:text-4xl">
+              <?php echo esc_html($heading); ?>
+            </h2>
+            <?php if (!empty($intro)) : ?>
+              <p class="max-w-2xl text-lg leading-relaxed text-gray-600">
+                <?php echo wp_kses_post($intro); ?>
+              </p>
+            <?php endif; ?>
+          </div>
+        <?php endif; ?>
+
+        <div class="overflow-hidden rounded-3xl border border-gray-100 bg-white/90 p-8 shadow-[0_30px_60px_-35px_rgba(15,23,42,0.35)] backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <?php if (!empty($badge)) : ?>
+              <span class="inline-flex items-center rounded-full bg-primary-light px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+                <?php echo esc_html($badge); ?>
+              </span>
+            <?php endif; ?>
+          </div>
+
+          <?php if (!empty($card_title)) : ?>
+            <h3 class="mt-6 text-2xl font-semibold text-slate-900">
+              <?php echo esc_html($card_title); ?>
+            </h3>
+          <?php endif; ?>
+
+          <?php if (!empty($card_body)) : ?>
+            <p class="mt-3 text-base leading-relaxed text-gray-600">
+              <?php echo wp_kses_post($card_body); ?>
+            </p>
+          <?php endif; ?>
+
+          <?php if (!empty($features)) : ?>
+            <ul class="mt-6 space-y-3">
+              <?php foreach ($features as $feature) :
+                $feature_text = isset($feature['text']) ? $feature['text'] : '';
+                if (empty($feature_text)) {
+                  continue;
+                }
+              ?>
+                <li class="flex items-start gap-3 text-sm font-medium text-slate-900">
+                  <span class="mt-1 inline-flex h-5 w-5 flex-none items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <svg class="h-3.5 w-3.5" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <path d="M4 8.5 6.667 11 12 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </span>
+                  <span class="leading-relaxed text-gray-700">
+                    <?php echo esc_html($feature_text); ?>
+                  </span>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          <?php endif; ?>
+
+          <?php if (!empty($note)) : ?>
+            <p class="mt-6 text-sm text-gray-500">
+              <?php echo wp_kses_post($note); ?>
+            </p>
+          <?php endif; ?>
+
+          <?php if (!empty($button_text) && !empty($button_link)) : ?>
+            <div class="mt-8">
+              <a href="<?php echo esc_url($button_link); ?>" class="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-primary/30 transition hover:bg-primary-dark">
+                <?php echo esc_html($button_text); ?>
+              </a>
+            </div>
+          <?php endif; ?>
+        </div>
+      </div>
+
+      <?php if (!empty($image)) : ?>
+        <div class="w-full flex-1 overflow-hidden rounded-3xl shadow-[0_40px_90px_-40px_rgba(15,23,42,0.45)]">
+          <img src="<?php echo esc_url($image); ?>" alt="" class="h-full w-full object-cover" loading="lazy" />
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+</section>

--- a/parts/solutions/services.php
+++ b/parts/solutions/services.php
@@ -1,0 +1,79 @@
+<?php
+  $defaults = function_exists('figma_rebuild_get_solutions_defaults') ? figma_rebuild_get_solutions_defaults() : [];
+  $services_defaults = isset($defaults['services']) ? $defaults['services'] : [];
+
+  $title = get_theme_mod('solutions_services_title', isset($services_defaults['title']) ? $services_defaults['title'] : '');
+  $description = get_theme_mod('solutions_services_description', isset($services_defaults['description']) ? $services_defaults['description'] : '');
+  $items = function_exists('figma_rebuild_get_repeater_mod')
+    ? figma_rebuild_get_repeater_mod('solutions_services_items', isset($services_defaults['items']) ? $services_defaults['items'] : [])
+    : [];
+?>
+
+<section class="bg-gray-50 py-20" id="solutions-services">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
+    <div class="mx-auto max-w-3xl text-center">
+      <?php if (!empty($title)) : ?>
+        <h2 class="text-3xl font-semibold text-slate-900 md:text-4xl">
+          <?php echo esc_html($title); ?>
+        </h2>
+      <?php endif; ?>
+
+      <?php if (!empty($description)) : ?>
+        <p class="mt-4 text-lg leading-relaxed text-gray-600">
+          <?php echo wp_kses_post($description); ?>
+        </p>
+      <?php endif; ?>
+    </div>
+
+    <?php if (!empty($items)) : ?>
+      <div class="mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <?php foreach ($items as $card) :
+          $card_label = isset($card['label']) ? $card['label'] : '';
+          $card_title = isset($card['title']) ? $card['title'] : '';
+          $card_description = isset($card['description']) ? $card['description'] : '';
+          $card_image = isset($card['image']) ? $card['image'] : '';
+          $card_link_label = isset($card['link_label']) ? $card['link_label'] : '';
+          $card_link_url = isset($card['link_url']) ? $card['link_url'] : '';
+        ?>
+          <article class="group flex h-full flex-col overflow-hidden rounded-3xl border border-white/40 bg-white shadow-[0_20px_60px_-30px_rgba(15,23,42,0.3)] transition duration-300 hover:-translate-y-1 hover:shadow-[0_30px_70px_-30px_rgba(15,23,42,0.35)]">
+            <?php if (!empty($card_image)) : ?>
+              <div class="relative aspect-[4/3] overflow-hidden">
+                <img src="<?php echo esc_url($card_image); ?>" alt="" class="h-full w-full object-cover transition duration-500 group-hover:scale-105" loading="lazy" />
+              </div>
+            <?php endif; ?>
+            <div class="flex flex-1 flex-col gap-4 px-6 pb-6 pt-6">
+              <?php if (!empty($card_label)) : ?>
+                <span class="inline-flex w-fit items-center rounded-full bg-primary-light/60 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-primary">
+                  <?php echo esc_html($card_label); ?>
+                </span>
+              <?php endif; ?>
+
+              <?php if (!empty($card_title)) : ?>
+                <h3 class="text-xl font-semibold text-slate-900">
+                  <?php echo esc_html($card_title); ?>
+                </h3>
+              <?php endif; ?>
+
+              <?php if (!empty($card_description)) : ?>
+                <p class="text-sm leading-relaxed text-gray-600">
+                  <?php echo wp_kses_post($card_description); ?>
+                </p>
+              <?php endif; ?>
+
+              <?php if (!empty($card_link_label) && !empty($card_link_url)) : ?>
+                <div class="mt-auto pt-2">
+                  <a class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-primary-dark" href="<?php echo esc_url($card_link_url); ?>">
+                    <?php echo esc_html($card_link_label); ?>
+                    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <path d="M5 10h8m0 0-3-3m3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                  </a>
+                </div>
+              <?php endif; ?>
+            </div>
+          </article>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+  </div>
+</section>

--- a/parts/solutions/zevip.php
+++ b/parts/solutions/zevip.php
@@ -1,0 +1,69 @@
+<?php
+  $defaults = function_exists('figma_rebuild_get_solutions_defaults') ? figma_rebuild_get_solutions_defaults() : [];
+  $zevip_defaults = isset($defaults['zevip']) ? $defaults['zevip'] : [];
+
+  $heading = get_theme_mod('solutions_zevip_heading', isset($zevip_defaults['heading']) ? $zevip_defaults['heading'] : '');
+  $intro = get_theme_mod('solutions_zevip_intro', isset($zevip_defaults['intro']) ? $zevip_defaults['intro'] : '');
+  $features = function_exists('figma_rebuild_get_repeater_mod')
+    ? figma_rebuild_get_repeater_mod('solutions_zevip_features', isset($zevip_defaults['features']) ? $zevip_defaults['features'] : [])
+    : [];
+  $button_text = get_theme_mod('solutions_zevip_button_text', isset($zevip_defaults['button_text']) ? $zevip_defaults['button_text'] : '');
+  $button_link = get_theme_mod('solutions_zevip_button_link', isset($zevip_defaults['button_link']) ? $zevip_defaults['button_link'] : '');
+  $image = get_theme_mod('solutions_zevip_image', isset($zevip_defaults['image']) ? $zevip_defaults['image'] : '');
+?>
+
+<section class="bg-gray-50 py-20" id="solutions-zevip">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6">
+    <div class="grid gap-12 lg:grid-cols-2 lg:items-center">
+      <div class="space-y-6">
+        <?php if (!empty($heading)) : ?>
+          <h2 class="text-3xl font-semibold text-slate-900 md:text-4xl">
+            <?php echo esc_html($heading); ?>
+          </h2>
+        <?php endif; ?>
+
+        <?php if (!empty($intro)) : ?>
+          <p class="text-lg leading-relaxed text-gray-600">
+            <?php echo wp_kses_post($intro); ?>
+          </p>
+        <?php endif; ?>
+
+        <?php if (!empty($features)) : ?>
+          <ul class="space-y-4">
+            <?php foreach ($features as $feature) :
+              $feature_text = isset($feature['text']) ? $feature['text'] : '';
+              if (empty($feature_text)) {
+                continue;
+              }
+            ?>
+              <li class="flex items-start gap-3 text-base text-gray-700">
+                <span class="mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full bg-primary/15 text-primary">
+                  <svg class="h-3.5 w-3.5" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <path d="M4 8.5 6.667 11 12 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </span>
+                <span class="leading-relaxed">
+                  <?php echo esc_html($feature_text); ?>
+                </span>
+              </li>
+            <?php endforeach; ?>
+          </ul>
+        <?php endif; ?>
+
+        <?php if (!empty($button_text) && !empty($button_link)) : ?>
+          <div class="pt-4">
+            <a href="<?php echo esc_url($button_link); ?>" class="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-primary/30 transition hover:bg-primary-dark">
+              <?php echo esc_html($button_text); ?>
+            </a>
+          </div>
+        <?php endif; ?>
+      </div>
+
+      <?php if (!empty($image)) : ?>
+        <div class="overflow-hidden rounded-3xl shadow-[0_40px_90px_-40px_rgba(15,23,42,0.45)]">
+          <img src="<?php echo esc_url($image); ?>" alt="" class="h-full w-full object-cover" loading="lazy" />
+        </div>
+      <?php endif; ?>
+    </div>
+  </div>
+</section>

--- a/templates/page-solutions.php
+++ b/templates/page-solutions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Template Name: Solutions
+ */
+
+get_header();
+?>
+
+<main id="main" class="solutions-page">
+  <?php get_template_part('parts/solutions/hero'); ?>
+  <?php get_template_part('parts/solutions/services'); ?>
+  <?php get_template_part('parts/solutions/section', null, ['section' => 'home', 'layout' => 'image-left']); ?>
+  <?php get_template_part('parts/solutions/section', null, ['section' => 'commercial', 'layout' => 'image-right']); ?>
+  <?php get_template_part('parts/solutions/section', null, ['section' => 'fleet', 'layout' => 'image-left']); ?>
+  <?php get_template_part('parts/solutions/zevip'); ?>
+  <?php get_template_part('parts/solutions/book'); ?>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add a dedicated Solutions page template composed of hero, services, detailed offering, ZEVIP, and contact sections
- create modular section partials with Tailwind styling and helper utilities for default content
- extend the Customizer with a Solutions panel, providing granular fields and repeaters for every section

## Testing
- npm run build
- php -l templates/page-solutions.php
- php -l parts/solutions/hero.php
- php -l parts/solutions/section.php
- php -l parts/solutions/services.php
- php -l parts/solutions/zevip.php
- php -l parts/solutions/book.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bd88232c8324bbaf5a53adddfc04