### PR TITLE
Create About and News page layouts

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * About page template loader.
+ *
+ * @package figma-rebuild
+ */
+
+require get_template_directory() . '/templates/page-about.php';

--- a/assets/css/kit/sections/about.css
+++ b/assets/css/kit/sections/about.css
@@ -1,0 +1,71 @@
+.about-highlights {
+  padding: clamp(3rem, 8vw, 6rem) 0;
+  background: #f8fafc;
+}
+
+.about-highlights__container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 5vw, 3rem);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+}
+
+.about-highlight {
+  position: relative;
+  min-height: clamp(16rem, 48vw, 22rem);
+  border-radius: 28px;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  color: #f8fafc;
+  padding: clamp(2.25rem, 7vw, 3.5rem);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-blend-mode: overlay;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.25);
+}
+
+.about-highlight::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.75) 100%);
+  pointer-events: none;
+}
+
+.about-highlight__content {
+  position: relative;
+  max-width: 560px;
+  z-index: 1;
+}
+
+.about-highlight__title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.about-highlight__subtitle {
+  margin: 0;
+  font-size: clamp(1rem, 3vw, 1.1rem);
+  line-height: 1.75;
+}
+
+.about-highlight--align-right {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.about-highlight--align-right .about-highlight__content {
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .about-highlight {
+    min-height: 18rem;
+    border-radius: 22px;
+  }
+}

--- a/assets/css/kit/sections/news-archive.css
+++ b/assets/css/kit/sections/news-archive.css
@@ -1,0 +1,127 @@
+.news-archive {
+  padding: clamp(3rem, 9vw, 6.5rem) 0 clamp(4rem, 10vw, 7.5rem);
+  background: #ffffff;
+}
+
+.news-archive__container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 5vw, 3rem);
+}
+
+.news-archive__grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 768px) {
+  .news-archive__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.news-archive__card {
+  background: #f1f5f9;
+  border-radius: 28px;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.news-archive__card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+}
+
+.news-archive__card.is-collapsed {
+  display: none;
+}
+
+.news-archive__link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.news-archive__media {
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+}
+
+.news-archive__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.news-archive__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.75rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #0f172a;
+}
+
+.news-archive__tag {
+  background: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+}
+
+.news-archive__date {
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.news-archive__title {
+  padding: 1rem 1.75rem 1.75rem;
+  margin: 0;
+  font-size: clamp(1.1rem, 3vw, 1.35rem);
+  font-weight: 700;
+  line-height: 1.5;
+  color: #0f172a;
+}
+
+.news-archive__more {
+  margin: clamp(2rem, 6vw, 3rem) auto 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #ffffff;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.9rem 2.5rem;
+  cursor: pointer;
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.35);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.news-archive__more:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 42px rgba(37, 99, 235, 0.4);
+}
+
+.news-archive__empty {
+  margin: 0;
+  padding: 2rem 0;
+  text-align: center;
+  color: #475569;
+  font-size: 1.05rem;
+}

--- a/assets/css/kit/sections/single-news.css
+++ b/assets/css/kit/sections/single-news.css
@@ -1,0 +1,119 @@
+.single-news {
+  background: #ffffff;
+}
+
+.single-news__hero {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: clamp(3rem, 9vw, 6rem) clamp(1.5rem, 5vw, 3rem) clamp(2rem, 6vw, 3.5rem);
+  display: grid;
+  gap: clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.single-news__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  background: #0ea5e9;
+  color: #0f172a;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  text-transform: uppercase;
+  width: fit-content;
+}
+
+.single-news__title {
+  margin: 0;
+  font-size: clamp(2.2rem, 6vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+
+.single-news__media {
+  position: relative;
+  border-radius: 32px;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.25);
+}
+
+.single-news__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.single-news__date {
+  position: absolute;
+  left: clamp(1rem, 4vw, 1.75rem);
+  bottom: clamp(1rem, 4vw, 1.75rem);
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.single-news__body {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 5vw, 3rem) clamp(3rem, 8vw, 6rem);
+  color: #1f2937;
+  font-size: 1.05rem;
+  line-height: 1.85;
+}
+
+.single-news__body > *:first-child {
+  margin-top: 0;
+}
+
+.single-news__body h2,
+.single-news__body h3,
+.single-news__body h4 {
+  margin-top: clamp(2rem, 6vw, 3rem);
+  margin-bottom: 1rem;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.single-news__body p {
+  margin-bottom: 1.5rem;
+}
+
+.single-news__body ul,
+.single-news__body ol {
+  margin: 1.5rem 0 1.5rem 1.5rem;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.single-news__body li {
+  padding-left: 0.5rem;
+}
+
+.single-news__body ol {
+  list-style: decimal;
+}
+
+.single-news__body ul {
+  list-style: disc;
+}
+
+@media (max-width: 640px) {
+  .single-news__media {
+    border-radius: 24px;
+  }
+
+  .single-news__date {
+    font-size: 0.78rem;
+    letter-spacing: 0.1em;
+  }
+}

--- a/assets/css/maxperr_kit.css
+++ b/assets/css/maxperr_kit.css
@@ -8,3 +8,6 @@
 @import url("kit/sections/testimony.css");
 @import url("kit/sections/news.css");
 @import url("kit/sections/products.css");
+@import url("kit/sections/about.css");
+@import url("kit/sections/news-archive.css");
+@import url("kit/sections/single-news.css");

--- a/news.php
+++ b/news.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * News page template loader.
+ *
+ * @package figma-rebuild
+ */
+
+require get_template_directory() . '/templates/page-news.php';

--- a/parts/about/highlights.php
+++ b/parts/about/highlights.php
@@ -1,0 +1,51 @@
+<?php
+if (!isset($about_sections) || !is_array($about_sections) || empty($about_sections)) {
+  return;
+}
+
+$about_section_id = isset($about_section_id) ? sanitize_title($about_section_id) : 'about-highlights';
+?>
+<section id="<?php echo esc_attr($about_section_id); ?>" class="about-highlights">
+  <div class="about-highlights__container">
+    <?php foreach ($about_sections as $index => $section) :
+      $title    = isset($section['title']) ? trim((string) $section['title']) : '';
+      $subtitle = isset($section['subtitle']) ? trim((string) $section['subtitle']) : '';
+      $image    = isset($section['image']) ? trim((string) $section['image']) : '';
+      $gradient = isset($section['gradient']) ? trim((string) $section['gradient']) : '';
+      $align    = isset($section['align']) ? trim((string) $section['align']) : 'left';
+
+      if ('' === $title && '' === $subtitle) {
+        continue;
+      }
+
+      $background_layers = [];
+      if ($gradient) {
+        $background_layers[] = $gradient;
+      }
+      if ($image) {
+        $background_layers[] = 'url(' . esc_url($image) . ')';
+      }
+      $background_style = '';
+      if (!empty($background_layers)) {
+        $background_style = ' style="background-image: ' . esc_attr(implode(', ', $background_layers)) . ';"';
+      }
+
+      $align_class = 'about-highlight--align-left';
+      if ('right' === strtolower($align)) {
+        $align_class = 'about-highlight--align-right';
+      }
+    ?>
+      <article class="about-highlight <?php echo esc_attr($align_class); ?>"<?php echo $background_style; ?> aria-label="<?php echo esc_attr($title ?: __('About highlight', 'figma-rebuild')); ?>">
+        <div class="about-highlight__content">
+          <?php if ($title) : ?>
+            <h2 class="about-highlight__title"><?php echo esc_html($title); ?></h2>
+          <?php endif; ?>
+
+          <?php if ($subtitle) : ?>
+            <p class="about-highlight__subtitle"><?php echo esc_html($subtitle); ?></p>
+          <?php endif; ?>
+        </div>
+      </article>
+    <?php endforeach; ?>
+  </div>
+</section>

--- a/parts/news/archive-grid.php
+++ b/parts/news/archive-grid.php
@@ -1,0 +1,96 @@
+<?php
+$initial_visible = isset($news_archive_initial) ? (int) $news_archive_initial : 6;
+if ($initial_visible < 1) {
+  $initial_visible = 6;
+}
+
+$news_query = new WP_Query([
+  'post_type'      => 'post',
+  'post_status'    => 'publish',
+  'posts_per_page' => -1,
+  'orderby'        => 'date',
+  'order'          => 'DESC',
+]);
+?>
+<section class="news-archive" data-news-archive>
+  <div class="news-archive__container">
+    <?php if ($news_query->have_posts()) : ?>
+      <div class="news-archive__grid">
+        <?php
+        $index = 0;
+        while ($news_query->have_posts()) :
+          $news_query->the_post();
+          $index++;
+          $is_hidden = $index > $initial_visible;
+          $card_classes = 'news-archive__card';
+          if ($is_hidden) {
+            $card_classes .= ' is-collapsed';
+          }
+
+          $permalink = get_permalink();
+          $title     = get_the_title();
+          $date_iso  = get_the_date(DATE_ATOM);
+          $date_text = get_the_date('Y-m-d');
+          $image_url = get_the_post_thumbnail_url(get_the_ID(), 'large');
+          if (!$image_url) {
+            $image_url = get_template_directory_uri() . '/src/images/bg_forest.jpg';
+          }
+
+          $categories = get_the_category();
+          $primary_category = '';
+          if (!empty($categories)) {
+            $primary_category = $categories[0]->name;
+          }
+        ?>
+          <article class="<?php echo esc_attr($card_classes); ?>">
+            <a class="news-archive__link" href="<?php echo esc_url($permalink); ?>">
+              <figure class="news-archive__media">
+                <img src="<?php echo esc_url($image_url); ?>" alt="<?php echo esc_attr($title); ?>">
+              </figure>
+              <div class="news-archive__meta">
+                <?php if ($primary_category) : ?>
+                  <span class="news-archive__tag"><?php echo esc_html($primary_category); ?></span>
+                <?php endif; ?>
+                <time class="news-archive__date" datetime="<?php echo esc_attr($date_iso); ?>"><?php echo esc_html($date_text); ?></time>
+              </div>
+              <h3 class="news-archive__title"><?php echo esc_html($title); ?></h3>
+            </a>
+          </article>
+        <?php endwhile; ?>
+      </div>
+
+      <?php if ($news_query->found_posts > $initial_visible) : ?>
+        <button class="news-archive__more" type="button" data-action="expand-news"><?php esc_html_e('Read More', 'figma-rebuild'); ?></button>
+      <?php endif; ?>
+    <?php else : ?>
+      <p class="news-archive__empty"><?php esc_html_e('No news available yet. Please check back soon.', 'figma-rebuild'); ?></p>
+    <?php endif; ?>
+  </div>
+</section>
+<?php
+wp_reset_postdata();
+
+if ($news_query->found_posts > $initial_visible) {
+  $script = <<<'JS'
+  document.addEventListener('DOMContentLoaded', function () {
+    var archive = document.querySelector('[data-news-archive]');
+    if (!archive) {
+      return;
+    }
+    var button = archive.querySelector('[data-action="expand-news"]');
+    if (!button) {
+      return;
+    }
+    button.addEventListener('click', function () {
+      archive.querySelectorAll('.news-archive__card.is-collapsed').forEach(function (card) {
+        card.classList.remove('is-collapsed');
+      });
+      button.setAttribute('hidden', 'hidden');
+    });
+  });
+JS;
+  if (!wp_script_is('figma-rebuild-app', 'enqueued')) {
+    wp_enqueue_script('figma-rebuild-app');
+  }
+  wp_add_inline_script('figma-rebuild-app', $script);
+}

--- a/single.php
+++ b/single.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Single post template loader.
+ *
+ * @package figma-rebuild
+ */
+
+require get_template_directory() . '/templates/single.php';

--- a/templates/page-about.php
+++ b/templates/page-about.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Template Name: About
+ */
+
+get_header();
+
+$hero_title = get_theme_mod('about_hero_title', __('About Us', 'figma-rebuild'));
+$hero_description = get_theme_mod(
+  'about_hero_description',
+  __('Reliable Energy. Renewable Future.', 'figma-rebuild')
+);
+$hero_bg_image = get_theme_mod(
+  'about_hero_bg_image',
+  get_template_directory_uri() . '/src/images/maxperr_expo.jpg'
+);
+$hero_button_text = '';
+$hero_button_link = '';
+$hero_id = 'about-hero';
+
+include get_template_directory() . '/parts/hero-template.php';
+
+$default_about_sections = [
+  [
+    'title'    => __('Our Value', 'figma-rebuild'),
+    'subtitle' => __('Maxperr Energy is committed to empowering communities by making dependable EV charging accessible for every household, workplace, and fleet.', 'figma-rebuild'),
+    'image'    => get_template_directory_uri() . '/src/images/maxperr_expo.jpg',
+    'gradient' => 'linear-gradient(135deg, rgba(15,23,42,0.78), rgba(59,130,246,0.55))',
+    'align'    => 'left',
+  ],
+  [
+    'title'    => __('Our Promise', 'figma-rebuild'),
+    'subtitle' => __('We build hardware and software that are intuitive to install, effortless to manage, and supported by a responsive technical team you can count on.', 'figma-rebuild'),
+    'image'    => get_template_directory_uri() . '/src/images/bg_house.jpg',
+    'gradient' => 'linear-gradient(135deg, rgba(15,23,42,0.82), rgba(2,132,199,0.55))',
+    'align'    => 'right',
+  ],
+  [
+    'title'    => __('Solutions Tailored to Your Needs', 'figma-rebuild'),
+    'subtitle' => __('From residential driveways to complex commercial depots, our specialists design charging ecosystems that scale with your goals and budget.', 'figma-rebuild'),
+    'image'    => get_template_directory_uri() . '/src/images/ev_charging_pic.jpg',
+    'gradient' => 'linear-gradient(135deg, rgba(15,23,42,0.78), rgba(34,197,94,0.45))',
+    'align'    => 'left',
+  ],
+  [
+    'title'    => __('Our Team', 'figma-rebuild'),
+    'subtitle' => __('Engineers, consultants, and advocates working together to accelerate electrification across North America with safe, future-ready infrastructure.', 'figma-rebuild'),
+    'image'    => get_template_directory_uri() . '/src/images/install_wallbox.png',
+    'gradient' => 'linear-gradient(135deg, rgba(15,23,42,0.82), rgba(56,189,248,0.45))',
+    'align'    => 'right',
+  ],
+];
+
+$about_sections = apply_filters('maxperr_about_sections', $default_about_sections);
+if (!is_array($about_sections)) {
+  $about_sections = $default_about_sections;
+}
+
+include get_template_directory() . '/parts/about/highlights.php';
+
+$pf = [];
+get_template_part('parts/partnership/power-future');
+
+get_footer();

--- a/templates/page-news.php
+++ b/templates/page-news.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Template Name: News
+ */
+
+get_header();
+
+$hero_title = get_theme_mod('news_page_hero_title', __('News', 'figma-rebuild'));
+$hero_description = '';
+$hero_button_text = '';
+$hero_button_link = '';
+$hero_bg_image = get_theme_mod(
+  'news_page_hero_bg_image',
+  get_template_directory_uri() . '/src/images/bg_house2.jpg'
+);
+$hero_id = 'news-hero';
+
+include get_template_directory() . '/parts/hero-template.php';
+
+$news_archive_initial = (int) apply_filters('maxperr_news_archive_initial', 6);
+if ($news_archive_initial < 1) {
+  $news_archive_initial = 6;
+}
+
+include get_template_directory() . '/parts/news/archive-grid.php';
+
+get_footer();

--- a/templates/single.php
+++ b/templates/single.php
@@ -1,0 +1,82 @@
+<?php
+get_header();
+?>
+<main id="main" class="single-news">
+  <?php if (have_posts()) : ?>
+    <?php while (have_posts()) : the_post();
+      $categories = get_the_category();
+      $primary_category = '';
+      if (!empty($categories)) {
+        $primary_category = $categories[0]->name;
+      }
+
+      $hero_image = get_the_post_thumbnail_url(get_the_ID(), 'full');
+      if (!$hero_image) {
+        $hero_image = get_template_directory_uri() . '/src/images/ev_charging_pic.jpg';
+      }
+
+      $date_iso  = get_the_date(DATE_ATOM);
+      $date_text = get_the_date('Y.m.d');
+    ?>
+      <section class="single-news__hero">
+        <?php if ($primary_category) : ?>
+          <span class="single-news__tag"><?php echo esc_html($primary_category); ?></span>
+        <?php endif; ?>
+
+        <h1 class="single-news__title"><?php the_title(); ?></h1>
+
+        <figure class="single-news__media">
+          <img src="<?php echo esc_url($hero_image); ?>" alt="<?php the_title_attribute(); ?>">
+          <time class="single-news__date" datetime="<?php echo esc_attr($date_iso); ?>"><?php echo esc_html($date_text); ?></time>
+        </figure>
+      </section>
+
+      <article class="single-news__body">
+        <?php the_content(); ?>
+      </article>
+    <?php endwhile; ?>
+  <?php else : ?>
+    <section class="single-news__hero">
+      <h1 class="single-news__title"><?php esc_html_e('News Update', 'figma-rebuild'); ?></h1>
+    </section>
+    <article class="single-news__body">
+      <p><?php esc_html_e('We could not find the news article you were looking for.', 'figma-rebuild'); ?></p>
+    </article>
+  <?php endif; ?>
+
+  <?php
+  $pf = [
+    'title'       => __('Need Help with EV Charger Installation?', 'figma-rebuild'),
+    'description' => __('Connect with our specialists for planning, installation, and ongoing support tailored to your property.', 'figma-rebuild'),
+    'cta_label'   => __('Book Consultation', 'figma-rebuild'),
+    'cta_link'    => '#book-consultation',
+    'hero_image'  => get_template_directory_uri() . '/src/images/install_wallbox.png',
+    'benefits'    => [
+      [
+        'title' => __('Site Assessment', 'figma-rebuild'),
+        'text'  => __('Get expert advice on power capacity, permitting, and layout before you break ground.', 'figma-rebuild'),
+      ],
+      [
+        'title' => __('Certified Installers', 'figma-rebuild'),
+        'text'  => __('Partner with licensed professionals trained on every Maxperr system.', 'figma-rebuild'),
+      ],
+      [
+        'title' => __('Smart Monitoring', 'figma-rebuild'),
+        'text'  => __('Track energy usage, billing, and uptime with our connected platform.', 'figma-rebuild'),
+      ],
+      [
+        'title' => __('Flexible Support', 'figma-rebuild'),
+        'text'  => __('Rely on priority maintenance plans to keep chargers running smoothly.', 'figma-rebuild'),
+      ],
+      [
+        'title' => __('Scalable Hardware', 'figma-rebuild'),
+        'text'  => __('Add more ports and features as driver demand grows at your site.', 'figma-rebuild'),
+      ],
+    ],
+  ];
+
+  get_template_part('parts/partnership/power-future');
+  ?>
+</main>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- add an About page template with configurable hero and highlight sections backed by new styling
- add a News archive template with a grid of cards, expandable "Read More" button, and supporting styles
- introduce a bespoke single post layout with hero media, formatted body typography, and reused "Power the Future" CTA

## Testing
- php -l about.php
- php -l templates/page-about.php
- php -l templates/page-news.php
- php -l templates/single.php
- php -l parts/about/highlights.php
- php -l parts/news/archive-grid.php


------
https://chatgpt.com/codex/tasks/task_e_68d481b9903883249c648871bf2bf8ba