### PR TITLE
Create About page template with alternating story sections

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,18 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&display=swap');
 
-/* 防止横向滚动 */
-html, body {
-  overflow-x: hidden;
-  max-width: 100%;
-}
-
-/* 确保所有容器不会超出视口宽度 */
-.solutions-page,
-.solutions-page * {
-  max-width: 100%;
-  box-sizing: border-box;
-}
-
 *, ::before, ::after{
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -587,8 +574,16 @@ video {
   border-width: 0;
 }
 
+.visible{
+  visibility: visible;
+}
+
 .static{
   position: static;
+}
+
+.absolute{
+  position: absolute;
 }
 
 .relative{
@@ -604,16 +599,8 @@ video {
   margin-right: auto;
 }
 
-.mb-1{
-  margin-bottom: 0.25rem;
-}
-
 .mb-12{
   margin-bottom: 3rem;
-}
-
-.mb-2{
-  margin-bottom: 0.5rem;
 }
 
 .mb-3{
@@ -658,10 +645,6 @@ video {
 
 .hidden{
   display: none;
-}
-
-.h-20{
-  height: 5rem;
 }
 
 .h-3\.5{
@@ -728,6 +711,10 @@ video {
   flex: none;
 }
 
+.grow{
+  flex-grow: 1;
+}
+
 .rotate-180{
   --tw-rotate: 180deg;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
@@ -749,12 +736,12 @@ video {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.grid-cols-3{
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
 .flex-col{
   flex-direction: column;
+}
+
+.flex-wrap{
+  flex-wrap: wrap;
 }
 
 .items-start{
@@ -827,6 +814,10 @@ video {
   overflow: hidden;
 }
 
+.text-wrap{
+  text-wrap: wrap;
+}
+
 .rounded-3xl{
   border-radius: 1.5rem;
 }
@@ -855,11 +846,6 @@ video {
 .border-gray-800{
   --tw-border-opacity: 1;
   border-color: rgb(31 41 55 / var(--tw-border-opacity, 1));
-}
-
-.bg-gray-100{
-  --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
 }
 
 .bg-gray-50{
@@ -1005,6 +991,10 @@ video {
   font-weight: 600;
 }
 
+.italic{
+  font-style: italic;
+}
+
 .leading-relaxed{
   line-height: 1.625;
 }
@@ -1015,11 +1005,6 @@ video {
 
 .leading-tight{
   line-height: 1.25;
-}
-
-.text-blue-600{
-  --tw-text-opacity: 1;
-  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-200{
@@ -1040,11 +1025,6 @@ video {
 .text-gray-700{
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity, 1));
-}
-
-.text-gray-800{
-  --tw-text-opacity: 1;
-  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-900{
@@ -1102,15 +1082,14 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.shadow-md{
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
 .shadow-primary\/30{
   --tw-shadow-color: rgb(11 95 255 / 0.3);
   --tw-shadow: var(--tw-shadow-colored);
+}
+
+.drop-shadow{
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
 .filter{
@@ -1129,16 +1108,6 @@ video {
   transition-duration: 150ms;
 }
 
-.transition-shadow{
-  transition-property: box-shadow;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-.duration-300{
-  transition-duration: 300ms;
-}
-
 .hover\:bg-primary-dark:hover{
   --tw-bg-opacity: 1;
   background-color: rgb(8 71 191 / var(--tw-bg-opacity, 1));
@@ -1147,12 +1116,6 @@ video {
 .hover\:text-primary:hover{
   --tw-text-opacity: 1;
   color: rgb(11 95 255 / var(--tw-text-opacity, 1));
-}
-
-.hover\:shadow-lg:hover{
-  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .focus\:border-primary:focus{

--- a/assets/css/kit/sections/about.css
+++ b/assets/css/kit/sections/about.css
@@ -1,223 +1,193 @@
-.about-page {
-  background-color: #f8fafc;
-}
+/* about.css – Full file
+   Full-bleed “half-blur + white text pane” cards for About page
+   -------------------------------------------------------------- */
 
-.about-story {
-  padding: clamp(72px, 10vw, 120px) 0;
-}
-
-.about-story__container {
-  width: min(1100px, 92vw);
-  margin: 0 auto;
-  display: grid;
-  gap: clamp(36px, 6vw, 64px);
-}
-
-.about-story__item {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(32px, 6vw, 72px);
-  padding: clamp(36px, 5vw, 72px);
-  border-radius: 36px;
-  background: var(--about-gradient, linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(255, 255, 255, 0.85)));
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.1);
-  overflow: hidden;
-}
-
-.about-story__item::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 55%),
-              radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 50%);
-  opacity: 0.9;
-}
-
-.about-story__item > * {
-  position: relative;
-  z-index: 1;
-}
-
-.about-story__media {
-  display: flex;
-  align-items: center;
-}
-
-.about-story__item--reverse {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.about-story__item--reverse .about-story__content {
-  order: 2;
-  text-align: left;
-}
-
-.about-story__item--reverse .about-story__media {
-  order: 1;
-}
-
-.about-story__item--gradient-1 { --about-gradient: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(255, 255, 255, 0.92)); }
-.about-story__item--gradient-2 { --about-gradient: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(255, 255, 255, 0.9)); }
-.about-story__item--gradient-3 { --about-gradient: linear-gradient(135deg, rgba(22, 163, 74, 0.1), rgba(255, 255, 255, 0.9)); }
-.about-story__item--gradient-4 { --about-gradient: linear-gradient(135deg, rgba(139, 92, 246, 0.12), rgba(255, 255, 255, 0.9)); }
-
-.about-story__kicker {
-  margin: 0 0 16px;
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #1d4ed8;
-}
-
-.about-story__title {
-  margin: 0 0 18px;
-  font-size: clamp(32px, 4vw, 48px);
-  line-height: 1.15;
-  font-weight: 800;
-  color: #0f172a;
-  letter-spacing: -0.02em;
-}
-
-.about-story__description {
-  margin: 0;
-  max-width: 520px;
-  font-size: clamp(16px, 2vw, 18px);
-  line-height: 1.7;
-  color: #1f2937;
-}
-
-.about-story__media-inner {
-  position: relative;
-  aspect-ratio: 4 / 3;
-  border-radius: 28px;
-  overflow: hidden;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(37, 99, 235, 0));
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
-}
-
-.about-story__media-inner::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 60%, rgba(15, 23, 42, 0.25) 100%);
-  mix-blend-mode: multiply;
-  pointer-events: none;
-}
-
-.about-story__media img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.about-power {
-  padding: clamp(80px, 12vw, 140px) 0;
-  background: linear-gradient(180deg, #ffffff 0%, #e0f2fe 100%);
-}
-
-.about-power__container {
-  max-width: 720px;
-  margin: 0 auto;
-  text-align: center;
-  padding: 0 24px;
-}
-
-.about-power__title {
-  margin: 0 0 16px;
-  font-size: clamp(36px, 5vw, 56px);
-  font-weight: 800;
-  color: #0f172a;
-  letter-spacing: -0.02em;
-}
-
-.about-power__description {
-  margin: 0 auto 36px;
-  max-width: 540px;
-  font-size: 18px;
-  line-height: 1.7;
-  color: #1f2937;
-}
-
-.about-power__actions {
-  display: flex;
-  justify-content: center;
-  gap: 18px;
-  flex-wrap: wrap;
-}
-
-.about-power__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 180px;
-  padding: 16px 32px;
-  border-radius: 999px;
-  font-weight: 600;
-  font-size: 16px;
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.about-power__button--primary {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
-  color: #ffffff;
-  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.35);
-}
-
-.about-power__button--primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.4);
-}
-
-.about-power__button--secondary {
-  background: #ffffff;
-  color: #0f172a;
-  border: 2px solid rgba(15, 23, 42, 0.85);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1);
-}
-
-.about-power__button--secondary:hover {
-  transform: translateY(-2px);
-  background: rgba(15, 23, 42, 0.9);
-  color: #ffffff;
-}
-
-@media (max-width: 1024px) {
-  .about-story__item,
-  .about-story__item--reverse {
-    grid-template-columns: 1fr;
+   :root{
+    --card-radius: 20px;
+    --card-shadow: 0 8px 30px rgba(0,0,0,.06);
+  
+    --accent: #3b82f6;   /* kicker */
+    --ink: #0f172a;      /* body text */
+    --headline: #2970A7; /* title color */
+  
+    /* 控制图片所占比例（50%~70% 推荐）。默认 60% */
+    --image-share: 60%;
+    /* 白到透明的过渡宽度（越大越柔和） */
+    --blend-span: 14%;
   }
-
-  .about-story__item--reverse .about-story__content {
-    order: 1;
+  
+  .about-story{
+    padding: 0;
+    overflow-x: clip;
+    background: transparent;
   }
-
-  .about-story__item--reverse .about-story__media {
-    order: 2;
-  }
-
-  .about-story__description {
+  
+  .about-story__container{
+    width: 100vw;
     max-width: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0; /* 卡片之间无间距 */
   }
-}
-
-@media (max-width: 640px) {
-  .about-story__item {
-    padding: clamp(28px, 8vw, 40px);
-    border-radius: 28px;
+  
+  /* ---------------- Card ---------------- */
+  
+  .blend-card{
+    position: relative;
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+  
+    aspect-ratio: 21 / 7;
+    min-height: 220px;
+    overflow: hidden;
+    border-radius: var(--card-radius);
+    box-shadow: var(--card-shadow);
+    background: #fff; /* 纯白文本面板的底色 */
   }
-
-  .about-story__media-inner {
-    border-radius: 22px;
-  }
-
-  .about-power__button {
+  
+  .blend-card__img,
+  .blend-card__img--blur{
+    position: absolute;
+    inset: 0;
     width: 100%;
-    max-width: 280px;
+    height: 100%;
+    object-fit: cover;
   }
-}
+  
+  .blend-card__img{
+    object-position: right center; /* 默认：人物/主体在右 */
+    z-index: 1;
+  }
+  
+  /* 同图模糊，只保留靠文本一侧，营造柔化过渡 */
+  .blend-card__img--blur{
+    z-index: 2;
+    filter: blur(14px) saturate(1.02) brightness(1.02);
+    transform: scale(1.06);
+    -webkit-mask-image: linear-gradient(
+      to right,
+      rgba(0,0,0,1) 0,
+      rgba(0,0,0,1) calc(100% - var(--image-share) + var(--blend-span)),
+      rgba(0,0,0,0) 100%
+    );
+            mask-image: linear-gradient(
+      to right,
+      rgba(0,0,0,1) 0,
+      rgba(0,0,0,1) calc(100% - var(--image-share) + var(--blend-span)),
+      rgba(0,0,0,0) 100%
+    );
+    pointer-events: none;
+  }
+  
+  /* 纯白文本面板 + 渐隐到透明，保证“留白是真白” */
+  .blend-card__shade{
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    background: linear-gradient(
+      to right,
+      #fff 0%,
+      #fff calc(100% - var(--image-share)),
+      rgba(255,255,255,0) calc(100% - var(--image-share) + var(--blend-span)),
+      rgba(255,255,255,0) 100%
+    );
+    pointer-events: none;
+  }
+  
+  /* 文本 */
+  .blend-card__content{
+    position: relative;
+    z-index: 4;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+    padding: clamp(16px, 4vw, 40px);
+    max-width: calc(100% - var(--image-share));
+    color: var(--ink);
+  }
+  
+  .blend-card__kicker{
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    font-weight: 700;
+    font-size: clamp(10px, 1.1vw, 12px);
+    color: var(--accent);
+    margin: 0 0 2px 0;
+  }
+  
+  .blend-card__title{
+    line-height: 1.12;
+    font-weight: 800;
+    font-size: clamp(20px, 3.2vw, 40px);
+    margin: 0;
+    color: var(--headline); /* #2970A7 */
+  }
+  
+  .blend-card__desc{
+    margin: 6px 0 0 0;
+    font-size: clamp(12px, 1.25vw, 16px);
+    line-height: 1.55;
+    color: #334155;
+  }
+  
+  /* --------- 自动让第 2 / 4 张卡片左右对调（偶数项） --------- */
+  
+  .about-story__container > .blend-card:nth-child(even) .blend-card__img{
+    object-position: left center;
+  }
+  
+  .about-story__container > .blend-card:nth-child(even) .blend-card__img--blur{
+    -webkit-mask-image: linear-gradient(
+      to left,
+      rgba(0,0,0,1) 0,
+      rgba(0,0,0,1) calc(100% - var(--image-share) + var(--blend-span)),
+      rgba(0,0,0,0) 100%
+    );
+            mask-image: linear-gradient(
+      to left,
+      rgba(0,0,0,1) 0,
+      rgba(0,0,0,1) calc(100% - var(--image-share) + var(--blend-span)),
+      rgba(0,0,0,0) 100%
+    );
+  }
+  
+  .about-story__container > .blend-card:nth-child(even) .blend-card__shade{
+    background: linear-gradient(
+      to left,
+      #fff 0%,
+      #fff calc(100% - var(--image-share)),
+      rgba(255,255,255,0) calc(100% - var(--image-share) + var(--blend-span)),
+      rgba(255,255,255,0) 100%
+    );
+  }
+  
+  .about-story__container > .blend-card:nth-child(even) .blend-card__content{
+    margin-left: auto; /* 文本面板贴右侧 */
+    text-align: left;
+  }
+  
+  /* ------- 可选：快速设置图片占比 50/60/70 的工具类 ------- */
+  
+  .blend-card.img-50{ --image-share: 50%; }
+  .blend-card.img-60{ --image-share: 60%; }
+  .blend-card.img-70{ --image-share: 70%; }
+  
+  /* Inset 变体（如需非满宽展示） */
+  .blend-card.blend-card--inset{
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+  }
+  
+  /* --------------- Responsive --------------- */
+  
+  @media (max-width: 768px){
+    .blend-card{ aspect-ratio: 16 / 9; min-height: 260px; }
+    .blend-card__content{ max-width: 80%; }
+    .blend-card__img{ object-position: 70% center; }
+  }
+  

--- a/assets/css/kit/sections/about.css
+++ b/assets/css/kit/sections/about.css
@@ -1,0 +1,223 @@
+.about-page {
+  background-color: #f8fafc;
+}
+
+.about-story {
+  padding: clamp(72px, 10vw, 120px) 0;
+}
+
+.about-story__container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(36px, 6vw, 64px);
+}
+
+.about-story__item {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(32px, 6vw, 72px);
+  padding: clamp(36px, 5vw, 72px);
+  border-radius: 36px;
+  background: var(--about-gradient, linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(255, 255, 255, 0.85)));
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.1);
+  overflow: hidden;
+}
+
+.about-story__item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 50%);
+  opacity: 0.9;
+}
+
+.about-story__item > * {
+  position: relative;
+  z-index: 1;
+}
+
+.about-story__media {
+  display: flex;
+  align-items: center;
+}
+
+.about-story__item--reverse {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.about-story__item--reverse .about-story__content {
+  order: 2;
+  text-align: left;
+}
+
+.about-story__item--reverse .about-story__media {
+  order: 1;
+}
+
+.about-story__item--gradient-1 { --about-gradient: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(255, 255, 255, 0.92)); }
+.about-story__item--gradient-2 { --about-gradient: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(255, 255, 255, 0.9)); }
+.about-story__item--gradient-3 { --about-gradient: linear-gradient(135deg, rgba(22, 163, 74, 0.1), rgba(255, 255, 255, 0.9)); }
+.about-story__item--gradient-4 { --about-gradient: linear-gradient(135deg, rgba(139, 92, 246, 0.12), rgba(255, 255, 255, 0.9)); }
+
+.about-story__kicker {
+  margin: 0 0 16px;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+}
+
+.about-story__title {
+  margin: 0 0 18px;
+  font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.15;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+}
+
+.about-story__description {
+  margin: 0;
+  max-width: 520px;
+  font-size: clamp(16px, 2vw, 18px);
+  line-height: 1.7;
+  color: #1f2937;
+}
+
+.about-story__media-inner {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border-radius: 28px;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(37, 99, 235, 0));
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+}
+
+.about-story__media-inner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 60%, rgba(15, 23, 42, 0.25) 100%);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.about-story__media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.about-power {
+  padding: clamp(80px, 12vw, 140px) 0;
+  background: linear-gradient(180deg, #ffffff 0%, #e0f2fe 100%);
+}
+
+.about-power__container {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
+  padding: 0 24px;
+}
+
+.about-power__title {
+  margin: 0 0 16px;
+  font-size: clamp(36px, 5vw, 56px);
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+}
+
+.about-power__description {
+  margin: 0 auto 36px;
+  max-width: 540px;
+  font-size: 18px;
+  line-height: 1.7;
+  color: #1f2937;
+}
+
+.about-power__actions {
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.about-power__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 180px;
+  padding: 16px 32px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 16px;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.about-power__button--primary {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.35);
+}
+
+.about-power__button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.4);
+}
+
+.about-power__button--secondary {
+  background: #ffffff;
+  color: #0f172a;
+  border: 2px solid rgba(15, 23, 42, 0.85);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1);
+}
+
+.about-power__button--secondary:hover {
+  transform: translateY(-2px);
+  background: rgba(15, 23, 42, 0.9);
+  color: #ffffff;
+}
+
+@media (max-width: 1024px) {
+  .about-story__item,
+  .about-story__item--reverse {
+    grid-template-columns: 1fr;
+  }
+
+  .about-story__item--reverse .about-story__content {
+    order: 1;
+  }
+
+  .about-story__item--reverse .about-story__media {
+    order: 2;
+  }
+
+  .about-story__description {
+    max-width: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .about-story__item {
+    padding: clamp(28px, 8vw, 40px);
+    border-radius: 28px;
+  }
+
+  .about-story__media-inner {
+    border-radius: 22px;
+  }
+
+  .about-power__button {
+    width: 100%;
+    max-width: 280px;
+  }
+}

--- a/assets/css/kit/sections/landing.css
+++ b/assets/css/kit/sections/landing.css
@@ -1,0 +1,330 @@
+/* ===================================
+   Responsive Landing Page Styles
+   =================================== */
+
+.landing-page {
+  background-color: #ffffff;
+  font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+}
+
+/* ===================================
+   Container and Layout
+   =================================== */
+
+.landing-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.landing-section {
+  padding: 60px 0;
+  width: 100%;
+}
+
+/* Alternating background colors for visual contrast */
+.landing-section:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.landing-content-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 60px;
+  min-height: 500px;
+}
+
+/* Reverse layout for alternating sections */
+.landing-content-wrapper--reverse {
+  flex-direction: row-reverse;
+}
+
+/* Special layout for team section */
+.landing-content-wrapper--team {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 60px;
+  align-items: center;
+}
+
+/* ===================================
+   Image Containers and Styling
+   =================================== */
+
+.landing-image-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.landing-image-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.landing-image-wrapper:hover {
+  transform: scale(1.02);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+}
+
+.landing-image {
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  object-fit: cover;
+  display: block;
+  aspect-ratio: 4/3;
+}
+
+/* ===================================
+   Text Content Styling
+   =================================== */
+
+.landing-text-content {
+  flex: 1;
+  padding: 20px 0;
+}
+
+.landing-section-title {
+  font-size: 24px;
+  font-weight: 600;
+  color: #007bff;
+  margin: 0 0 16px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.landing-main-heading {
+  font-size: 32px;
+  font-weight: 700;
+  color: #333;
+  margin: 0 0 20px 0;
+  line-height: 1.3;
+}
+
+/* Responsive font sizes */
+@media (max-width: 1024px) {
+  .landing-main-heading {
+    font-size: 28px;
+  }
+}
+
+@media (max-width: 768px) {
+  .landing-main-heading {
+    font-size: 24px;
+  }
+}
+
+.landing-description {
+  font-size: 16px;
+  line-height: 1.6;
+  color: #333;
+  margin: 0;
+  max-width: 600px;
+}
+
+/* ===================================
+   Team Grid Layout
+   =================================== */
+
+.landing-team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  max-width: 600px;
+}
+
+.landing-team-member {
+  position: relative;
+  border-radius: 15px;
+  overflow: hidden;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  background: #f8f9fa;
+}
+
+.landing-team-member:hover {
+  transform: scale(1.02);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.15);
+}
+
+.landing-team-image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.landing-team-member:hover .landing-team-image {
+  transform: scale(1.05);
+}
+
+/* ===================================
+   Section-specific Styling
+   =================================== */
+
+.landing-section--our-value {
+  background: linear-gradient(135deg, rgba(0, 123, 255, 0.05) 0%, rgba(255, 255, 255, 1) 100%);
+}
+
+.landing-section--our-promise {
+  background: linear-gradient(135deg, rgba(40, 167, 69, 0.05) 0%, rgba(249, 249, 249, 1) 100%);
+}
+
+.landing-section--solutions {
+  background: linear-gradient(135deg, rgba(255, 193, 7, 0.05) 0%, rgba(255, 255, 255, 1) 100%);
+}
+
+.landing-section--our-team {
+  background: linear-gradient(135deg, rgba(108, 117, 125, 0.05) 0%, rgba(249, 249, 249, 1) 100%);
+  padding: 80px 0;
+}
+
+/* ===================================
+   Responsive Design - Tablet
+   =================================== */
+
+@media (max-width: 1024px) {
+  .landing-container {
+    padding: 0 30px;
+  }
+  
+  .landing-content-wrapper {
+    gap: 40px;
+    min-height: 400px;
+  }
+  
+  .landing-content-wrapper--team {
+    gap: 40px;
+  }
+  
+  .landing-team-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 15px;
+  }
+  
+  .landing-team-image {
+    height: 160px;
+  }
+}
+
+/* ===================================
+   Responsive Design - Mobile
+   =================================== */
+
+@media (max-width: 768px) {
+  .landing-section {
+    padding: 40px 0;
+  }
+  
+  .landing-container {
+    padding: 0 20px;
+  }
+  
+  /* Stack vertically on mobile - image on top, text below */
+  .landing-content-wrapper,
+  .landing-content-wrapper--reverse {
+    flex-direction: column;
+    gap: 30px;
+    min-height: auto;
+  }
+  
+  /* Team section also stacks vertically */
+  .landing-content-wrapper--team {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+  }
+  
+  .landing-image-wrapper {
+    max-width: 100%;
+  }
+  
+  .landing-section-title {
+    font-size: 20px;
+  }
+  
+  
+  .landing-description {
+    font-size: 16px;
+  }
+  
+  .landing-team-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
+    max-width: 100%;
+  }
+  
+  .landing-team-image {
+    height: 140px;
+  }
+  
+  .landing-section--our-team {
+    padding: 60px 0;
+  }
+}
+
+/* ===================================
+   Additional Hover Effects
+   =================================== */
+
+.landing-text-content {
+  transition: transform 0.2s ease;
+}
+
+/* Only apply hover effects on larger screens */
+@media (min-width: 769px) {
+  .landing-section:hover .landing-text-content {
+    transform: translateY(-2px);
+  }
+}
+
+/* Focus states for accessibility */
+.landing-image-wrapper:focus-within,
+.landing-team-member:focus-within {
+  outline: 2px solid #007bff;
+  outline-offset: 4px;
+}
+
+/* Loading state for images */
+.landing-image,
+.landing-team-image {
+  background-color: #f8f9fa;
+  background-image: linear-gradient(45deg, #f0f0f0 25%, transparent 25%), 
+                    linear-gradient(-45deg, #f0f0f0 25%, transparent 25%), 
+                    linear-gradient(45deg, transparent 75%, #f0f0f0 75%), 
+                    linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
+  background-size: 20px 20px;
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+}
+
+/* ===================================
+   Print Styles
+   =================================== */
+
+@media print {
+  .landing-section {
+    padding: 20px 0;
+    break-inside: avoid;
+  }
+  
+  .landing-image-wrapper,
+  .landing-team-member {
+    box-shadow: none;
+  }
+  
+  .landing-content-wrapper,
+  .landing-content-wrapper--reverse,
+  .landing-content-wrapper--team {
+    flex-direction: column;
+    gap: 20px;
+  }
+}

--- a/assets/css/maxperr_kit.css
+++ b/assets/css/maxperr_kit.css
@@ -9,3 +9,4 @@
 @import url("kit/sections/news.css");
 @import url("kit/sections/products.css");
 @import url("kit/sections/about.css");
+@import url("kit/sections/landing.css");

--- a/assets/css/maxperr_kit.css
+++ b/assets/css/maxperr_kit.css
@@ -8,3 +8,4 @@
 @import url("kit/sections/testimony.css");
 @import url("kit/sections/news.css");
 @import url("kit/sections/products.css");
+@import url("kit/sections/about.css");

--- a/header.php
+++ b/header.php
@@ -41,10 +41,11 @@
   $is_solutions_page = is_page('solutions');
   $is_products_page = is_page('products');
   $is_partnership_page = is_page('partnership');
+  $is_about_page = is_page('about');
 ?>
 
-<header class="site-header<?php echo ($is_solutions_page || $is_products_page || $is_partnership_page) ? ' site-header--subpage' : ''; ?>">
-  <?php if ($is_solutions_page || $is_products_page || $is_partnership_page) : ?>
+<header class="site-header<?php echo ($is_solutions_page || $is_products_page || $is_partnership_page || $is_about_page) ? ' site-header--subpage' : ''; ?>">
+  <?php if ($is_solutions_page || $is_products_page || $is_partnership_page || $is_about_page) : ?>
     <div class="subpage-header">
       <a href="<?php echo esc_url(home_url('/')); ?>" class="subpage-header__logo" aria-label="<?php esc_attr_e('Go to homepage', 'figma-rebuild'); ?>">
         <img src="<?php echo esc_url(get_template_directory_uri()); ?>/src/images/logo_maxperr.png"
@@ -119,7 +120,7 @@
               </div>
             </div>
           <?php else : ?>
-            <a href="<?php echo esc_url($item['url']); ?>" class="subpage-header__link<?php echo (($is_solutions_page && $item['label'] === 'Solutions') || ($is_products_page && $item['label'] === 'Products') || ($is_partnership_page && $item['label'] === 'Partnership')) ? ' subpage-header__link--active' : ''; ?>">
+            <a href="<?php echo esc_url($item['url']); ?>" class="subpage-header__link<?php echo (($is_solutions_page && $item['label'] === 'Solutions') || ($is_products_page && $item['label'] === 'Products') || ($is_partnership_page && $item['label'] === 'Partnership') || ($is_about_page && $item['label'] === 'About')) ? ' subpage-header__link--active' : ''; ?>">
               <?php echo esc_html($item['label']); ?>
             </a>
           <?php endif; ?>
@@ -152,7 +153,7 @@
     <div class="mobile-menu" id="mobile-menu">
       <div class="px-6 py-4 space-y-4 max-w-7xl mx-auto">
         <?php foreach ($nav_items as $item) : ?>
-          <a href="<?php echo esc_url($item['url']); ?>" class="nav-link<?php echo (($is_solutions_page && $item['label'] === 'Solutions') || ($is_products_page && $item['label'] === 'Products') || ($is_partnership_page && $item['label'] === 'Partnership')) ? ' nav-link--active' : ''; ?>">
+          <a href="<?php echo esc_url($item['url']); ?>" class="nav-link<?php echo (($is_solutions_page && $item['label'] === 'Solutions') || ($is_products_page && $item['label'] === 'Products') || ($is_partnership_page && $item['label'] === 'Partnership') || ($is_about_page && $item['label'] === 'About')) ? ' nav-link--active' : ''; ?>">
             <?php echo esc_html($item['label']); ?>
           </a>
         <?php endforeach; ?>

--- a/page-landing-demo.php
+++ b/page-landing-demo.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Template Name: Landing Page Demo
+ * 
+ * This page demonstrates the responsive landing page template
+ */
+
+get_header(); ?>
+
+<main class="landing-page">
+  
+  <!-- Our Value Section -->
+  <section class="landing-section landing-section--our-value">
+    <div class="landing-container">
+      <div class="landing-content-wrapper">
+        <div class="landing-image-container">
+          <div class="landing-image-wrapper">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/bg_house.jpg" 
+                 alt="<?php esc_attr_e('Sustainable energy solutions for modern homes', 'figma-rebuild'); ?>"
+                 class="landing-image">
+          </div>
+        </div>
+        
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Our Value', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Maxperr Energy offers cutting-edge EV charging solutions for a sustainable future', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('From intelligent charging to smart energy management, we design systems that ensure dependable performance for homes, businesses, and fleets. Our innovative technology creates a seamless transition to sustainable transportation.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Our Promise Section -->
+  <section class="landing-section landing-section--our-promise">
+    <div class="landing-container">
+      <div class="landing-content-wrapper landing-content-wrapper--reverse">
+        <div class="landing-image-container">
+          <div class="landing-image-wrapper">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/ev_app_control.jpg" 
+                 alt="<?php esc_attr_e('Smart EV charging app interface', 'figma-rebuild'); ?>"
+                 class="landing-image">
+          </div>
+        </div>
+        
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Our Promise', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Our fast EV chargers deliver up to 80% in just 30 minutes. Intelligent and efficient charging.', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('Experience the future of electric vehicle charging with our advanced technology. Smart charging protocols and user-friendly interfaces make the transition to electric mobility seamless and convenient for every driver.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Solutions Tailored Section -->
+  <section class="landing-section landing-section--solutions">
+    <div class="landing-container">
+      <div class="landing-content-wrapper">
+        <div class="landing-image-container">
+          <div class="landing-image-wrapper">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/maxperr_expo.jpg" 
+                 alt="<?php esc_attr_e('Maxperr team presenting solutions at technology expo', 'figma-rebuild'); ?>"
+                 class="landing-image">
+          </div>
+        </div>
+        
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Solutions Tailored to Your Needs', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Fast EV Chargers, Smart Charging Solutions, Eco-Friendly EV Chargers, Installation Services, Maintenance and Support, Innovative Charging', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('From single residential units to large commercial installations, our comprehensive suite of charging solutions is designed to meet diverse energy needs with precision and reliability. Every solution is customized for optimal performance.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Our Team Section -->
+  <section class="landing-section landing-section--our-team">
+    <div class="landing-container">
+      <div class="landing-content-wrapper landing-content-wrapper--team">
+        
+        <!-- Team Grid -->
+        <div class="landing-team-grid">
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/maxperr_home_10kW.png" 
+                 alt="<?php esc_attr_e('Maxperr Home 10kW Charging Station', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/maxperr_smart_30kW.png" 
+                 alt="<?php esc_attr_e('Maxperr Smart 30kW Commercial Charger', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/install_wallbox.png" 
+                 alt="<?php esc_attr_e('Professional wallbox installation service', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/ev_nav_map.jpg" 
+                 alt="<?php esc_attr_e('EV charging station navigation and mapping', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/bg_house2.jpg" 
+                 alt="<?php esc_attr_e('Modern home with integrated EV charging', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/bg_forest.jpg" 
+                 alt="<?php esc_attr_e('Sustainable energy in natural environments', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+        </div>
+        
+        <!-- Team Text Content -->
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Our Team', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Let us know as soon as convenient, advancing sustainable energy innovation throughout development', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('Our diverse team of engineers, designers, and energy specialists work collaboratively to deliver cutting-edge solutions that drive the future of sustainable transportation and energy infrastructure. Together, we are building tomorrow\'s energy ecosystem today.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<style>
+/* Additional inline styles for demo purposes */
+.landing-page {
+  margin-top: -80px; /* Adjust for header if needed */
+  padding-top: 80px;
+}
+
+/* Ensure smooth scrolling */
+html {
+  scroll-behavior: smooth;
+}
+
+/* Add some extra visual polish */
+.landing-section {
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(0, 123, 255, 0.3), transparent);
+  opacity: 0.5;
+}
+</style>
+
+<?php get_footer(); ?>

--- a/parts/about/hero.php
+++ b/parts/about/hero.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * About Hero Section using shared subpage template.
+ */
+
+$template_uri = get_template_directory_uri();
+
+$hero_title = get_theme_mod('about_hero_title', __('About Us', 'figma-rebuild'));
+$hero_description = get_theme_mod(
+  'about_hero_description',
+  __('We build reliable energy ecosystems that accelerate electrification and empower communities to thrive.', 'figma-rebuild')
+);
+$hero_button_text = get_theme_mod('about_hero_button_text', __('Discover Our Story', 'figma-rebuild'));
+$hero_button_link = get_theme_mod('about_hero_button_link', '#about-story');
+
+$hero_bg_image = get_theme_mod('about_hero_bg_image', $template_uri . '/src/images/maxperr_expo.jpg');
+
+$hero_id = 'about-hero';
+
+include get_template_directory() . '/parts/hero-template.php';

--- a/parts/about/power-future.php
+++ b/parts/about/power-future.php
@@ -1,17 +1,118 @@
 <?php
 /**
- * About page CTA - reusing partnership layout inspiration.
+ * About page CTA - Power the Future Together Section
  */
 ?>
 
-<section id="about-power-future" class="about-power">
-  <div class="about-power__container">
-    <h2 class="about-power__title"><?php esc_html_e("Let's Power the Future Together.", 'figma-rebuild'); ?></h2>
-    <p class="about-power__description"><?php esc_html_e('Connect with our specialists to plan your next charging milestone or unlock real-time support.', 'figma-rebuild'); ?></p>
-
-    <div class="about-power__actions">
-      <a href="#contact" class="about-power__button about-power__button--primary"><?php esc_html_e('Book Consultation', 'figma-rebuild'); ?></a>
-      <a href="#support" class="about-power__button about-power__button--secondary"><?php esc_html_e('Technical Support', 'figma-rebuild'); ?></a>
+<section id="power-future" class="power-future-section">
+  <div class="power-future__container">
+    <h2 class="power-future__title">Let's Power the Future Together.</h2>
+    
+    <div class="power-future__buttons">
+      <a href="#contact" class="power-future__button power-future__button--primary">Contact Us</a>
+      <a href="#careers" class="power-future__button power-future__button--secondary">Careers</a>
     </div>
   </div>
 </section>
+
+<style>
+.power-future-section {
+  padding: 80px 0;
+  background: #ffffff;
+  border: 1px solid #e0f2fe;
+}
+
+.power-future__container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0 24px;
+  text-align: center;
+}
+
+.power-future__title {
+  margin: 0 0 32px;
+  font-size: 48px;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+}
+
+.power-future__buttons {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.power-future__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 32px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 16px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 140px;
+}
+
+.power-future__button--primary {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.power-future__button--primary:hover {
+  background: #1d4ed8;
+}
+
+.power-future__button--secondary {
+  background: #ffffff;
+  color: #0f172a;
+  border: 2px solid #0f172a;
+}
+
+.power-future__button--secondary:hover {
+  background: #0f172a;
+  color: #ffffff;
+}
+
+@media (max-width: 768px) {
+  .power-future-section {
+    padding: 60px 0;
+  }
+  
+  .power-future__container {
+    padding: 0 16px;
+  }
+  
+  .power-future__title {
+    font-size: 36px;
+  }
+  
+  .power-future__buttons {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .power-future__button {
+    width: 100%;
+    max-width: 280px;
+    padding: 14px 28px;
+    font-size: 15px;
+  }
+}
+
+@media (max-width: 480px) {
+  .power-future__title {
+    font-size: 32px;
+  }
+  
+  .power-future__button {
+    padding: 12px 24px;
+    font-size: 14px;
+  }
+}
+</style>

--- a/parts/about/power-future.php
+++ b/parts/about/power-future.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * About page CTA - reusing partnership layout inspiration.
+ */
+?>
+
+<section id="about-power-future" class="about-power">
+  <div class="about-power__container">
+    <h2 class="about-power__title"><?php esc_html_e("Let's Power the Future Together.", 'figma-rebuild'); ?></h2>
+    <p class="about-power__description"><?php esc_html_e('Connect with our specialists to plan your next charging milestone or unlock real-time support.', 'figma-rebuild'); ?></p>
+
+    <div class="about-power__actions">
+      <a href="#contact" class="about-power__button about-power__button--primary"><?php esc_html_e('Book Consultation', 'figma-rebuild'); ?></a>
+      <a href="#support" class="about-power__button about-power__button--secondary"><?php esc_html_e('Technical Support', 'figma-rebuild'); ?></a>
+    </div>
+  </div>
+</section>

--- a/parts/about/story.php
+++ b/parts/about/story.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * About page story sections.
+ * About page story sections – full-bleed image card with half-blur text overlay.
  */
 
 $default_sections = [
@@ -35,7 +35,6 @@ $default_sections = [
 ];
 
 $about_sections = get_theme_mod('about_story_sections', $default_sections);
-
 if (!is_array($about_sections) || empty($about_sections)) {
   $about_sections = $default_sections;
 }
@@ -49,38 +48,35 @@ if (!is_array($about_sections) || empty($about_sections)) {
       $description = trim($section['description'] ?? '');
       $image = $section['image'] ?? '';
       $image_alt = $section['image_alt'] ?? '';
-      $is_reverse = $index % 2 === 1;
-      $item_classes = 'about-story__item about-story__item--gradient-' . ($index + 1);
-      if ($is_reverse) {
-        $item_classes .= ' about-story__item--reverse';
-      }
-
       if (is_numeric($image)) {
-        $image = wp_get_attachment_image_url((int)$image, 'large');
+        $image = wp_get_attachment_image_url((int)$image, 'full');
       }
+      if (!$image) continue;
     ?>
-      <article class="<?php echo esc_attr($item_classes); ?>">
-        <div class="about-story__content">
+      <article class="blend-card" data-card="<?php echo (int)$index; ?>">
+        <!-- 基底原图（不模糊） -->
+        <img class="blend-card__img" src="<?php echo esc_url($image); ?>" alt="<?php echo esc_attr($image_alt); ?>" loading="lazy" />
+
+        <!-- 左半区的同图模糊层（仅显示左侧，用 mask 裁切） -->
+        <img class="blend-card__img blend-card__img--blur" src="<?php echo esc_url($image); ?>" alt="" aria-hidden="true" />
+
+        <!-- 左侧淡入的白色/雾化遮罩，增强对比度 -->
+        <span class="blend-card__shade" aria-hidden="true"></span>
+
+        <!-- 文字层：放在左半区 -->
+        <div class="blend-card__content">
           <?php if ($kicker) : ?>
-            <p class="about-story__kicker"><?php echo esc_html($kicker); ?></p>
+            <p class="blend-card__kicker"><?php echo esc_html($kicker); ?></p>
           <?php endif; ?>
 
           <?php if ($title) : ?>
-            <h2 class="about-story__title"><?php echo esc_html($title); ?></h2>
+            <h2 class="blend-card__title"><?php echo esc_html($title); ?></h2>
           <?php endif; ?>
 
           <?php if ($description) : ?>
-            <p class="about-story__description"><?php echo esc_html($description); ?></p>
+            <p class="blend-card__desc"><?php echo esc_html($description); ?></p>
           <?php endif; ?>
         </div>
-
-        <?php if ($image) : ?>
-          <div class="about-story__media">
-            <div class="about-story__media-inner">
-              <img src="<?php echo esc_url($image); ?>" alt="<?php echo esc_attr($image_alt); ?>">
-            </div>
-          </div>
-        <?php endif; ?>
       </article>
     <?php endforeach; ?>
   </div>

--- a/parts/about/story.php
+++ b/parts/about/story.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * About page story sections.
+ */
+
+$default_sections = [
+  [
+    'kicker' => __('Our Value', 'figma-rebuild'),
+    'title' => __('Reliable Energy, Tailored to Everyday Life', 'figma-rebuild'),
+    'description' => __('From intelligent charging to smart energy management, we design systems that ensure dependable performance for homes, businesses, and fleets.', 'figma-rebuild'),
+    'image' => get_template_directory_uri() . '/src/images/ev_charging_pic.jpg',
+    'image_alt' => __('Technician installing a charger on brick wall', 'figma-rebuild'),
+  ],
+  [
+    'kicker' => __('Our Promise', 'figma-rebuild'),
+    'title' => __('Partners in Every Step of Electrification', 'figma-rebuild'),
+    'description' => __('We stay beside our customers with dedicated service teams, robust warranties, and insight that simplifies each installation.', 'figma-rebuild'),
+    'image' => get_template_directory_uri() . '/src/images/ev_app_control.jpg',
+    'image_alt' => __('Driver monitoring EV charging from mobile app', 'figma-rebuild'),
+  ],
+  [
+    'kicker' => __('Tailored Solutions', 'figma-rebuild'),
+    'title' => __('Built for Communities, Campuses, and Corridors', 'figma-rebuild'),
+    'description' => __('Whether deploying a single charger or building a regional network, our engineering team adapts hardware and software to match your roadmap.', 'figma-rebuild'),
+    'image' => get_template_directory_uri() . '/src/images/maxperr_expo.jpg',
+    'image_alt' => __('Team demonstrating charging solutions at an expo', 'figma-rebuild'),
+  ],
+  [
+    'kicker' => __('Our Team', 'figma-rebuild'),
+    'title' => __('A Collective of Builders, Engineers, and Advocates', 'figma-rebuild'),
+    'description' => __('We bring together energy experts, product designers, and field technicians who are united by a mission to make electrification effortless.', 'figma-rebuild'),
+    'image' => get_template_directory_uri() . '/src/images/maxperr_home_10kW.png',
+    'image_alt' => __('Maxperr team collaborating beside charging units', 'figma-rebuild'),
+  ],
+];
+
+$about_sections = get_theme_mod('about_story_sections', $default_sections);
+
+if (!is_array($about_sections) || empty($about_sections)) {
+  $about_sections = $default_sections;
+}
+?>
+
+<section id="about-story" class="about-story">
+  <div class="about-story__container">
+    <?php foreach ($about_sections as $index => $section) :
+      $kicker = trim($section['kicker'] ?? '');
+      $title = trim($section['title'] ?? '');
+      $description = trim($section['description'] ?? '');
+      $image = $section['image'] ?? '';
+      $image_alt = $section['image_alt'] ?? '';
+      $is_reverse = $index % 2 === 1;
+      $item_classes = 'about-story__item about-story__item--gradient-' . ($index + 1);
+      if ($is_reverse) {
+        $item_classes .= ' about-story__item--reverse';
+      }
+
+      if (is_numeric($image)) {
+        $image = wp_get_attachment_image_url((int)$image, 'large');
+      }
+    ?>
+      <article class="<?php echo esc_attr($item_classes); ?>">
+        <div class="about-story__content">
+          <?php if ($kicker) : ?>
+            <p class="about-story__kicker"><?php echo esc_html($kicker); ?></p>
+          <?php endif; ?>
+
+          <?php if ($title) : ?>
+            <h2 class="about-story__title"><?php echo esc_html($title); ?></h2>
+          <?php endif; ?>
+
+          <?php if ($description) : ?>
+            <p class="about-story__description"><?php echo esc_html($description); ?></p>
+          <?php endif; ?>
+        </div>
+
+        <?php if ($image) : ?>
+          <div class="about-story__media">
+            <div class="about-story__media-inner">
+              <img src="<?php echo esc_url($image); ?>" alt="<?php echo esc_attr($image_alt); ?>">
+            </div>
+          </div>
+        <?php endif; ?>
+      </article>
+    <?php endforeach; ?>
+  </div>
+</section>

--- a/templates/page-about.php
+++ b/templates/page-about.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Template Name: About
+ */
+
+get_header();
+?>
+
+<main id="main" class="about-page">
+  <?php get_template_part('parts/about/hero'); ?>
+  <?php get_template_part('parts/about/story'); ?>
+  <?php get_template_part('parts/about/power-future'); ?>
+</main>
+
+<?php get_footer(); ?>

--- a/templates/page-landing.php
+++ b/templates/page-landing.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Template Name: Responsive Landing Page
+ * 
+ * A responsive landing page with four main sections:
+ * - Our Value (image left, text right)
+ * - Our Promise (image right, text left)  
+ * - Solutions Tailored (image left, text right)
+ * - Our Team (team grid with text right)
+ */
+
+get_header(); ?>
+
+<main class="landing-page">
+  
+  <!-- Our Value Section -->
+  <section class="landing-section landing-section--our-value">
+    <div class="landing-container">
+      <div class="landing-content-wrapper">
+        <div class="landing-image-container">
+          <div class="landing-image-wrapper">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/ev_charging_pic.jpg" 
+                 alt="<?php esc_attr_e('Maxperr Energy charging solutions for sustainable future', 'figma-rebuild'); ?>"
+                 class="landing-image">
+          </div>
+        </div>
+        
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Our Value', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Maxperr Energy offers cutting-edge EV charging solutions for a sustainable future', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('We provide intelligent charging infrastructure that adapts to your needs, whether for residential, commercial, or fleet applications. Our innovative technology ensures reliable, efficient, and environmentally conscious energy solutions.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Our Promise Section -->
+  <section class="landing-section landing-section--our-promise">
+    <div class="landing-container">
+      <div class="landing-content-wrapper landing-content-wrapper--reverse">
+        <div class="landing-image-container">
+          <div class="landing-image-wrapper">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/ev_app_control.jpg" 
+                 alt="<?php esc_attr_e('Our fast EV chargers deliver up to 80% in just 30 minutes', 'figma-rebuild'); ?>"
+                 class="landing-image">
+          </div>
+        </div>
+        
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Our Promise', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Our fast EV chargers deliver up to 80% in just 30 minutes. Intelligent and efficient charging.', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('Experience the future of electric vehicle charging with our advanced technology. Smart charging protocols and user-friendly interfaces make the transition to electric mobility seamless and convenient for everyone.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Solutions Tailored Section -->
+  <section class="landing-section landing-section--solutions">
+    <div class="landing-container">
+      <div class="landing-content-wrapper">
+        <div class="landing-image-container">
+          <div class="landing-image-wrapper">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/maxperr_expo.jpg" 
+                 alt="<?php esc_attr_e('Solutions Tailored to Your Needs', 'figma-rebuild'); ?>"
+                 class="landing-image">
+          </div>
+        </div>
+        
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Solutions Tailored to Your Needs', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Fast EV Chargers, Smart Charging Solutions, Eco-Friendly EV Chargers, Installation Services, Maintenance and Support, Innovative Charging', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('From single residential units to large commercial installations, our comprehensive suite of charging solutions is designed to meet diverse energy needs with precision and reliability.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Our Team Section -->
+  <section class="landing-section landing-section--our-team">
+    <div class="landing-container">
+      <div class="landing-content-wrapper landing-content-wrapper--team">
+        
+        <!-- Team Grid -->
+        <div class="landing-team-grid">
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/maxperr_home_10kW.png" 
+                 alt="<?php esc_attr_e('Team Member 1', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/maxperr_smart_30kW.png" 
+                 alt="<?php esc_attr_e('Team Member 2', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/install_wallbox.png" 
+                 alt="<?php esc_attr_e('Team Member 3', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/ev_nav_map.jpg" 
+                 alt="<?php esc_attr_e('Team Member 4', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/bg_house.jpg" 
+                 alt="<?php esc_attr_e('Team Member 5', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+          <div class="landing-team-member">
+            <img src="<?php echo get_template_directory_uri(); ?>/src/images/bg_house2.jpg" 
+                 alt="<?php esc_attr_e('Team Member 6', 'figma-rebuild'); ?>"
+                 class="landing-team-image">
+          </div>
+        </div>
+        
+        <!-- Team Text Content -->
+        <div class="landing-text-content">
+          <h2 class="landing-section-title"><?php esc_html_e('Our Team', 'figma-rebuild'); ?></h2>
+          <h3 class="landing-main-heading"><?php esc_html_e('Let us know as soon as convenient, advancing sustainable energy innovation throughout development', 'figma-rebuild'); ?></h3>
+          <p class="landing-description">
+            <?php esc_html_e('Our diverse team of engineers, designers, and energy specialists work collaboratively to deliver cutting-edge solutions that drive the future of sustainable transportation and energy infrastructure.', 'figma-rebuild'); ?>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add an About page template that composes the hero, story grid, and CTA sections
- implement alternating gradient story blocks and a CTA section styled to match the provided wireframe
- update navigation to apply subpage styling on About and import the new About styles into the kit bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d49c2e0b048324b54f944950132c42