### PR TITLE
Add Eco 12kW AC product detail page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1091,6 +1091,12 @@ video {
   --tw-shadow: var(--tw-shadow-colored);
 }
 
+.ring{
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .drop-shadow{
   --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);

--- a/assets/css/kit/pages/product-detail.css
+++ b/assets/css/kit/pages/product-detail.css
@@ -1,0 +1,506 @@
+.product-detail-page {
+  background-color: #ffffff;
+  color: #0f172a;
+  padding-bottom: 8rem;
+}
+
+.product-detail-page section {
+  width: min(1180px, 92vw);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.product-detail-hero {
+  padding-top: 6rem;
+  padding-bottom: 5rem;
+}
+
+.product-detail-hero__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2.5rem;
+  margin-bottom: 3.5rem;
+}
+
+.product-detail-hero__model {
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.75rem);
+  font-weight: 600;
+  color: #0b1120;
+  margin-bottom: 0.75rem;
+}
+
+.product-detail-hero__subtitle {
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  max-width: 30rem;
+  color: #475569;
+}
+
+.product-detail-hero__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.75rem 2.75rem;
+  border-radius: 999px;
+  text-decoration: none;
+  box-shadow: 0 18px 35px rgba(37, 99, 235, 0.25);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  white-space: nowrap;
+}
+
+.product-detail-hero__cta:hover,
+.product-detail-hero__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 45px rgba(29, 78, 216, 0.28);
+}
+
+.product-detail-hero__media {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.product-detail-hero__media-item {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.product-detail-hero__image-wrapper {
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at top, rgba(148, 163, 184, 0.2), rgba(15, 23, 42, 0.05));
+  padding: 1.5rem;
+  min-height: 18rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.product-detail-hero__image-wrapper img {
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.product-detail-hero__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.product-detail-hero__metric-value {
+  font-size: clamp(2rem, 1.8vw + 1.5rem, 3rem);
+  font-weight: 700;
+  color: #0b1120;
+}
+
+.product-detail-hero__metric-label {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #475569;
+}
+
+.cost-efficient {
+  padding-top: 1rem;
+  padding-bottom: 6rem;
+}
+
+.cost-efficient__header {
+  margin-bottom: 2.5rem;
+}
+
+.cost-efficient__title {
+  font-size: clamp(1.75rem, 1.3vw + 1.75rem, 2.5rem);
+  font-weight: 600;
+  color: #0b1120;
+}
+
+.cost-efficient__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  grid-template-areas:
+    "tall medium"
+    "wide wide";
+}
+
+.cost-card {
+  position: relative;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.08);
+  background-color: #0f172a;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+}
+
+.cost-card__image {
+  position: relative;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+}
+
+.cost-card--tall .cost-card__image {
+  aspect-ratio: 3 / 4;
+}
+
+.cost-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.cost-card:hover .cost-card__image img {
+  transform: scale(1.05);
+}
+
+.cost-card__content {
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cost-card__eyebrow {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.cost-card__description {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.cost-card--tall {
+  grid-area: tall;
+}
+
+.cost-card--medium {
+  grid-area: medium;
+}
+
+.cost-card--wide {
+  grid-area: wide;
+}
+
+.cost-card--wide .cost-card__image {
+  aspect-ratio: 16 / 9;
+}
+
+.product-specs {
+  padding-top: 4rem;
+  padding-bottom: 6rem;
+}
+
+.product-specs__header {
+  margin-bottom: 2.75rem;
+}
+
+.product-specs__title {
+  font-size: clamp(1.75rem, 1.2vw + 1.6rem, 2.5rem);
+  font-weight: 600;
+  color: #0b1120;
+}
+
+.product-specs__groups {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.product-specs__group-title {
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1e293b;
+  margin-bottom: 1rem;
+}
+
+.product-specs__list {
+  margin: 0;
+}
+
+.product-specs__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 0.65rem 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.product-specs__row:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.product-specs__row dt {
+  font-weight: 500;
+  flex: 0 0 50%;
+  max-width: 52%;
+  color: #1e293b;
+}
+
+.product-specs__row dd {
+  margin: 0;
+  flex: 1;
+  text-align: right;
+  color: #0f172a;
+}
+
+.compare-models {
+  background: #f8fafc;
+  padding: 5rem 0 6rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.compare-models__header {
+  width: min(1180px, 92vw);
+  margin: 0 auto 3rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.compare-models__title {
+  font-size: clamp(1.8rem, 1.2vw + 1.6rem, 2.5rem);
+  font-weight: 600;
+  color: #0b1120;
+  margin-bottom: 0.75rem;
+}
+
+.compare-models__subtitle {
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: #475569;
+  max-width: 32rem;
+}
+
+.compare-models__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.compare-models__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.compare-models__action--primary {
+  background: #0ea5e9;
+  color: #ffffff;
+  box-shadow: 0 15px 35px rgba(14, 165, 233, 0.25);
+}
+
+.compare-models__action--primary:hover,
+.compare-models__action--primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 45px rgba(14, 165, 233, 0.3);
+}
+
+.compare-models__action--ghost {
+  border: 1.5px solid rgba(30, 64, 175, 0.2);
+  color: #1d4ed8;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.compare-models__action--ghost:hover,
+.compare-models__action--ghost:focus-visible {
+  border-color: rgba(30, 64, 175, 0.5);
+  color: #1e3a8a;
+}
+
+.compare-models__columns {
+  width: min(1180px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2rem;
+}
+
+.compare-models__column {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.compare-models__visual {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 9rem;
+}
+
+.compare-models__visual img {
+  max-width: 160px;
+  height: auto;
+}
+
+.compare-models__model {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0b1120;
+}
+
+.compare-models__select {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: linear-gradient(135deg, rgba(241, 245, 249, 0.9), rgba(226, 232, 240, 0.8));
+  color: #1e293b;
+  font-weight: 500;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.compare-models__select svg {
+  width: 12px;
+  height: 8px;
+}
+
+.compare-models__spec-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.compare-models__spec-group h4 {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #334155;
+}
+
+.compare-models__spec-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.compare-models__spec-row span:last-child {
+  font-weight: 500;
+  color: #0b1120;
+}
+
+.compare-models__add {
+  border-radius: 1.5rem;
+  border: 1.5px dashed rgba(37, 99, 235, 0.35);
+  background: transparent;
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 1.05rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 2rem;
+  cursor: not-allowed;
+}
+
+.compare-models__add span {
+  opacity: 0.8;
+}
+
+@media (max-width: 1024px) {
+  .product-detail-hero__media {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .compare-models__header {
+    flex-direction: column;
+  }
+
+  .compare-models__columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .product-detail-hero__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .product-detail-hero__media {
+    grid-template-columns: 1fr;
+  }
+
+  .cost-efficient__grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "tall"
+      "medium"
+      "wide";
+  }
+
+  .cost-card {
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
+  }
+
+  .product-specs__groups {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-models__columns {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-models__add {
+    min-height: 200px;
+  }
+}
+
+@media (max-width: 640px) {
+  .product-detail-hero {
+    padding-top: 4rem;
+  }
+
+  .product-detail-hero__cta {
+    align-self: stretch;
+    justify-content: center;
+  }
+
+  .product-detail-hero__image-wrapper {
+    min-height: 14rem;
+    border-radius: 1rem;
+  }
+
+  .compare-models__action {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .compare-models__columns {
+    gap: 1.5rem;
+  }
+}

--- a/assets/css/maxperr_kit.css
+++ b/assets/css/maxperr_kit.css
@@ -12,3 +12,4 @@
 @import url("kit/sections/landing.css");
 @import url("kit/pages/news.css");
 @import url("kit/pages/news-paragraph.css");
+@import url("kit/pages/product-detail.css");

--- a/page-product-eco-12kw.php
+++ b/page-product-eco-12kw.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Template Name: Product Detail - Eco 12kW AC
+ */
+
+get_header();
+
+$template_uri = get_template_directory_uri();
+?>
+
+<main class="product-detail-page">
+  <section class="product-detail-hero" id="product-hero">
+    <div class="product-detail-hero__header">
+      <div class="product-detail-hero__intro">
+        <p class="product-detail-hero__model"><?php esc_html_e('Eco 12kW AC', 'figma-rebuild'); ?></p>
+        <p class="product-detail-hero__subtitle"><?php esc_html_e('Residential-friendly, energy-efficient charging tailored for modern EV households.', 'figma-rebuild'); ?></p>
+      </div>
+      <a class="product-detail-hero__cta" href="#compare-models"><?php esc_html_e('Order Now', 'figma-rebuild'); ?></a>
+    </div>
+
+    <div class="product-detail-hero__media">
+      <figure class="product-detail-hero__media-item">
+        <div class="product-detail-hero__image-wrapper">
+          <img src="<?php echo esc_url($template_uri . '/src/images/maxperr_home_10kW.png'); ?>"
+               alt="<?php esc_attr_e('Eco 12kW AC home charger perspective view', 'figma-rebuild'); ?>">
+        </div>
+        <figcaption class="product-detail-hero__metric">
+          <span class="product-detail-hero__metric-value">20%</span>
+          <span class="product-detail-hero__metric-label"><?php esc_html_e('Higher charging efficiency vs. standard Level 2 units', 'figma-rebuild'); ?></span>
+        </figcaption>
+      </figure>
+
+      <figure class="product-detail-hero__media-item">
+        <div class="product-detail-hero__image-wrapper">
+          <img src="<?php echo esc_url($template_uri . '/src/images/ev_charging_pic.jpg'); ?>"
+               alt="<?php esc_attr_e('Charging cable and connector detail', 'figma-rebuild'); ?>">
+        </div>
+        <figcaption class="product-detail-hero__metric">
+          <span class="product-detail-hero__metric-value">30</span>
+          <span class="product-detail-hero__metric-label"><?php esc_html_e('Miles of range added per hour of charge', 'figma-rebuild'); ?></span>
+        </figcaption>
+      </figure>
+
+      <figure class="product-detail-hero__media-item">
+        <div class="product-detail-hero__image-wrapper">
+          <img src="<?php echo esc_url($template_uri . '/src/images/install_wallbox.png'); ?>"
+               alt="<?php esc_attr_e('Front panel close-up with indicator lights', 'figma-rebuild'); ?>">
+        </div>
+        <figcaption class="product-detail-hero__metric">
+          <span class="product-detail-hero__metric-value">3</span>
+          <span class="product-detail-hero__metric-label"><?php esc_html_e('Smart charging modes for peak, off-peak, and balanced use', 'figma-rebuild'); ?></span>
+        </figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section class="cost-efficient" id="cost-efficient">
+    <div class="cost-efficient__header">
+      <h2 class="cost-efficient__title"><?php esc_html_e('Cost Efficient Home Charger', 'figma-rebuild'); ?></h2>
+    </div>
+
+    <div class="cost-efficient__grid">
+      <article class="cost-card cost-card--tall">
+        <div class="cost-card__image">
+          <img src="<?php echo esc_url($template_uri . '/src/images/install_wallbox_news.png'); ?>"
+               alt="<?php esc_attr_e('Homeowner interacting with wall-mounted charger', 'figma-rebuild'); ?>">
+        </div>
+        <div class="cost-card__content">
+          <p class="cost-card__eyebrow"><?php esc_html_e('Intelligent & Efficient', 'figma-rebuild'); ?></p>
+          <p class="cost-card__description"><?php esc_html_e('Automated load balancing and dynamic scheduling optimize every charging session while protecting household circuits.', 'figma-rebuild'); ?></p>
+        </div>
+      </article>
+
+      <article class="cost-card cost-card--medium">
+        <div class="cost-card__image">
+          <img src="<?php echo esc_url($template_uri . '/src/images/maxperr_smart_30kW.png'); ?>"
+               alt="<?php esc_attr_e('Internal electronics close-up', 'figma-rebuild'); ?>">
+        </div>
+        <div class="cost-card__content">
+          <p class="cost-card__eyebrow"><?php esc_html_e('Secure & Reliable', 'figma-rebuild'); ?></p>
+          <p class="cost-card__description"><?php esc_html_e('Built-in surge protection, ground fault monitoring, and OTA firmware keep the unit safe and up to date.', 'figma-rebuild'); ?></p>
+        </div>
+      </article>
+
+      <article class="cost-card cost-card--wide">
+        <div class="cost-card__image">
+          <img src="<?php echo esc_url($template_uri . '/src/images/ev_app_control.jpg'); ?>"
+               alt="<?php esc_attr_e('Mobile app displaying charging session overview', 'figma-rebuild'); ?>">
+        </div>
+        <div class="cost-card__content">
+          <p class="cost-card__eyebrow"><?php esc_html_e('Flexible & Convenient', 'figma-rebuild'); ?></p>
+          <p class="cost-card__description"><?php esc_html_e('Remote start, charging reminders, and utility rate integrations give you full control from anywhere.', 'figma-rebuild'); ?></p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="product-specs" id="product-specs">
+    <div class="product-specs__header">
+      <h2 class="product-specs__title"><?php esc_html_e('Product Specs', 'figma-rebuild'); ?></h2>
+    </div>
+
+    <div class="product-specs__groups">
+      <div class="product-specs__group">
+        <h3 class="product-specs__group-title"><?php esc_html_e('Design', 'figma-rebuild'); ?></h3>
+        <dl class="product-specs__list">
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Height', 'figma-rebuild'); ?></dt>
+            <dd>420 mm</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Width', 'figma-rebuild'); ?></dt>
+            <dd>260 mm</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Depth', 'figma-rebuild'); ?></dt>
+            <dd>120 mm</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Weight', 'figma-rebuild'); ?></dt>
+            <dd>9.8 kg</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="product-specs__group">
+        <h3 class="product-specs__group-title"><?php esc_html_e('Input', 'figma-rebuild'); ?></h3>
+        <dl class="product-specs__list">
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Grid Connection', 'figma-rebuild'); ?></dt>
+            <dd>Single-phase</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Voltage Range', 'figma-rebuild'); ?></dt>
+            <dd>200 – 240 V AC</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Maximum Current', 'figma-rebuild'); ?></dt>
+            <dd>50 A</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Frequency', 'figma-rebuild'); ?></dt>
+            <dd>50 / 60 Hz</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="product-specs__group">
+        <h3 class="product-specs__group-title"><?php esc_html_e('Output', 'figma-rebuild'); ?></h3>
+        <dl class="product-specs__list">
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Maximum Power', 'figma-rebuild'); ?></dt>
+            <dd>12 kW</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Charging Connector', 'figma-rebuild'); ?></dt>
+            <dd>Type 1 (SAE J1772) / Type 2 option</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Cable Length', 'figma-rebuild'); ?></dt>
+            <dd>7.5 m</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Efficiency', 'figma-rebuild'); ?></dt>
+            <dd>≥ 95%</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="product-specs__group">
+        <h3 class="product-specs__group-title"><?php esc_html_e('System', 'figma-rebuild'); ?></h3>
+        <dl class="product-specs__list">
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Connectivity', 'figma-rebuild'); ?></dt>
+            <dd>Wi-Fi / Ethernet / Bluetooth LE</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Smart Features', 'figma-rebuild'); ?></dt>
+            <dd>App control, load management, OTA updates</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('User Interface', 'figma-rebuild'); ?></dt>
+            <dd>LED status ring, capacitive touch panel</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Communication', 'figma-rebuild'); ?></dt>
+            <dd>OCPP 1.6 JSON, Modbus TCP</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="product-specs__group">
+        <h3 class="product-specs__group-title"><?php esc_html_e('Safety', 'figma-rebuild'); ?></h3>
+        <dl class="product-specs__list">
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Protection', 'figma-rebuild'); ?></dt>
+            <dd>IP55 enclosure, IK08 impact rating</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Certifications', 'figma-rebuild'); ?></dt>
+            <dd>UL 2231, UL 2594, IEC 61851-1, CE</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Ground Fault', 'figma-rebuild'); ?></dt>
+            <dd>20 mA CCID, self-test</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Surge Protection', 'figma-rebuild'); ?></dt>
+            <dd>Type 2 SPD, 8 kA</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="product-specs__group">
+        <h3 class="product-specs__group-title"><?php esc_html_e('Environment', 'figma-rebuild'); ?></h3>
+        <dl class="product-specs__list">
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Operating Temperature', 'figma-rebuild'); ?></dt>
+            <dd>-30°C to 50°C</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Storage Temperature', 'figma-rebuild'); ?></dt>
+            <dd>-40°C to 70°C</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Humidity', 'figma-rebuild'); ?></dt>
+            <dd>5% – 95% RH, non-condensing</dd>
+          </div>
+          <div class="product-specs__row">
+            <dt><?php esc_html_e('Altitude', 'figma-rebuild'); ?></dt>
+            <dd>≤ 2000 m</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  </section>
+
+  <section class="compare-models" id="compare-models">
+    <div class="compare-models__header">
+      <div class="compare-models__intro">
+        <h2 class="compare-models__title"><?php esc_html_e('Compare Models', 'figma-rebuild'); ?></h2>
+        <p class="compare-models__subtitle"><?php esc_html_e('Review core specs side-by-side or schedule a call with our specialists for tailored guidance.', 'figma-rebuild'); ?></p>
+      </div>
+      <div class="compare-models__actions">
+        <a class="compare-models__action compare-models__action--primary" href="#contact"><?php esc_html_e('Book Consultation', 'figma-rebuild'); ?></a>
+        <a class="compare-models__action compare-models__action--ghost" href="#product-hero"><?php esc_html_e('Order Now', 'figma-rebuild'); ?></a>
+      </div>
+    </div>
+
+    <div class="compare-models__columns">
+      <div class="compare-models__column">
+        <div class="compare-models__visual">
+          <img src="<?php echo esc_url($template_uri . '/src/images/maxperr_home_10kW.png'); ?>"
+               alt="<?php esc_attr_e('Eco 12kW AC charger', 'figma-rebuild'); ?>">
+        </div>
+        <h3 class="compare-models__model"><?php esc_html_e('Eco 12kW AC', 'figma-rebuild'); ?></h3>
+        <div class="compare-models__select" role="presentation">
+          <span><?php esc_html_e('Matte Graphite', 'figma-rebuild'); ?></span>
+          <svg viewBox="0 0 12 8" aria-hidden="true"><path d="M1 1l5 6 5-6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Design', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Dimensions', 'figma-rebuild'); ?></span><span>420 × 260 × 120 mm</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Weight', 'figma-rebuild'); ?></span><span>9.8 kg</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Input', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Voltage Range', 'figma-rebuild'); ?></span><span>200 – 240 V AC</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Max Current', 'figma-rebuild'); ?></span><span>50 A</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Output', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Max Power', 'figma-rebuild'); ?></span><span>12 kW</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Connector', 'figma-rebuild'); ?></span><span>Type 1 / Type 2</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('System', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Connectivity', 'figma-rebuild'); ?></span><span>Wi-Fi / Ethernet</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Smart Modes', 'figma-rebuild'); ?></span><span>App, OTA, load balance</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Environment', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Operating Temp.', 'figma-rebuild'); ?></span><span>-30°C to 50°C</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Ingress Rating', 'figma-rebuild'); ?></span><span>IP55</span></div>
+        </div>
+      </div>
+
+      <div class="compare-models__column">
+        <div class="compare-models__visual">
+          <img src="<?php echo esc_url($template_uri . '/src/images/maxperr_smart_30kW.png'); ?>"
+               alt="<?php esc_attr_e('Smart 30kW DC charger', 'figma-rebuild'); ?>">
+        </div>
+        <h3 class="compare-models__model"><?php esc_html_e('Smart 30kW DC', 'figma-rebuild'); ?></h3>
+        <div class="compare-models__select" role="presentation">
+          <span><?php esc_html_e('Brushed Silver', 'figma-rebuild'); ?></span>
+          <svg viewBox="0 0 12 8" aria-hidden="true"><path d="M1 1l5 6 5-6" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Design', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Dimensions', 'figma-rebuild'); ?></span><span>520 × 310 × 180 mm</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Weight', 'figma-rebuild'); ?></span><span>18.5 kg</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Input', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Voltage Range', 'figma-rebuild'); ?></span><span>380 – 480 V AC</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Max Current', 'figma-rebuild'); ?></span><span>48 A</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Output', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Max Power', 'figma-rebuild'); ?></span><span>30 kW</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Connector', 'figma-rebuild'); ?></span><span>CCS1 / CHAdeMO</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('System', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Connectivity', 'figma-rebuild'); ?></span><span>Wi-Fi / 4G / Ethernet</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Smart Modes', 'figma-rebuild'); ?></span><span>Dynamic load share, demand response</span></div>
+        </div>
+        <div class="compare-models__spec-group">
+          <h4><?php esc_html_e('Environment', 'figma-rebuild'); ?></h4>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Operating Temp.', 'figma-rebuild'); ?></span><span>-35°C to 55°C</span></div>
+          <div class="compare-models__spec-row"><span><?php esc_html_e('Ingress Rating', 'figma-rebuild'); ?></span><span>IP54</span></div>
+        </div>
+      </div>
+
+      <button type="button" class="compare-models__add" aria-disabled="true">
+        <span>+ <?php esc_html_e('Add Model', 'figma-rebuild'); ?></span>
+      </button>
+    </div>
+  </section>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add a dedicated Eco 12kW AC product detail template with hero, benefits grid, specs, and comparison sections
- author tailored CSS for the product detail layout and include it in the aggregated kit stylesheet
- rebuild the compiled CSS bundle for distribution

## Testing
- php -l page-product-eco-12kw.php
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5be5534848324ba4928ed0809c476